### PR TITLE
Add support for new GraalVM naming scheme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .scala-build/
-/.bsp/
+.bsp/
+.metals/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Generate an index with
 ```bash
 $ GH_TOKEN="****" ./scala-cli.sh src
 ```
+or
+```powershell
+$Env:GH_TOKEN="*****"
+scala-cli src
+```
 
 Just `./scala-cli.sh src` can work if `GH_TOKEN` is not set, but it usually gets
 rate-limited by the GitHub API. You can read more about creating a token

--- a/src/GenerateIndex.scala
+++ b/src/GenerateIndex.scala
@@ -11,13 +11,15 @@ object GenerateIndex {
 
     val output = "index.json"
 
-    val correttoIndex0 = Corretto.fullIndex(GhToken.token)
-    val graalvmIndex0  = Graalvm.fullIndex(GhToken.token)
-    val adoptIndex0    = Temurin.fullIndex(GhToken.token)
-    val zuluIndex0     = Zulu.index()
-    val libericaIndex0 = Liberica.index()
+    val correttoIndex0      = Corretto.fullIndex(GhToken.token)
+    val graalvmLegacyIndex0 = GraalvmLegacy.fullIndex(GhToken.token)
+    val graalvmIndex0       = Graalvm.fullIndex(GhToken.token)
+    val adoptIndex0         = Temurin.fullIndex(GhToken.token)
+    val zuluIndex0          = Zulu.index()
+    val libericaIndex0      = Liberica.index()
 
-    val json = (graalvmIndex0 + adoptIndex0 + zuluIndex0 + libericaIndex0 + correttoIndex0).json
+    val json =
+      (graalvmLegacyIndex0 + graalvmIndex0 + adoptIndex0 + zuluIndex0 + libericaIndex0 + correttoIndex0).json
     val dest = os.Path(output, os.pwd)
     os.write.over(dest, json)
     System.err.println(s"Wrote $dest")

--- a/src/Graalvm.scala
+++ b/src/Graalvm.scala
@@ -1,51 +1,36 @@
 object Graalvm {
 
   def fullIndex(ghToken: String): Index = {
-    val graalvmIndex0      = index(ghToken, "8")
-    val graalvmJdk11Index0 = index(ghToken, "11")
-    val graalvmJdk16Index0 = index(ghToken, "16")
     val graalvmJdk17Index0 = index(ghToken, "17")
-    val graalvmJdk19Index0 = index(ghToken, "19")
-    graalvmIndex0 + graalvmJdk11Index0 + graalvmJdk16Index0 + graalvmJdk17Index0 + graalvmJdk19Index0
+    val graalvmJdk20Index0 = index(ghToken, "20")
+    graalvmJdk17Index0 + graalvmJdk20Index0
   }
 
   def index(
     ghToken: String,
-    javaVersion: String,
-    javaVersionInName: java.lang.Boolean = null
+    javaVersion: String
   ): Index = {
-
-    val javaVersionInName0 = Option(javaVersionInName)
-      .map(x => x: Boolean)
-      .getOrElse(javaVersion != "8")
-    val name =
-      if (javaVersionInName0)
-        s"jdk@graalvm-java$javaVersion"
-      else
-        "jdk@graalvm"
 
     val ghOrg  = "graalvm"
     val ghProj = "graalvm-ce-builds"
     val releases0 = Release.releaseIds(ghOrg, ghProj, ghToken)
       .filter(!_.prerelease)
 
-    val assetNamePrefix = s"graalvm-ce-java$javaVersion-"
-
     def osOpt(input: String): Option[(String, String)] =
       if (input.startsWith("linux-"))
         Some(("linux", input.stripPrefix("linux-")))
-      else if (input.startsWith("darwin-"))
-        Some(("darwin", input.stripPrefix("darwin-")))
+      else if (input.startsWith("macos-"))
+        Some(("darwin", input.stripPrefix("macos-")))
       else if (input.startsWith("windows-"))
         Some(("windows", input.stripPrefix("windows-")))
       else
         None
 
     def archOpt(input: String): Option[(String, String)] =
-      if (input.startsWith("amd64-"))
-        Some(("amd64", input.stripPrefix("amd64-")))
-      else if (input.startsWith("aarch64-"))
-        Some(("arm64", input.stripPrefix("aarch64-")))
+      if (input.startsWith("x64_"))
+        Some(("amd64", input.stripPrefix("x64_bin")))
+      else if (input.startsWith("aarch64_"))
+        Some(("arm64", input.stripPrefix("aarch64_bin")))
       else
         None
 
@@ -55,23 +40,30 @@ object Graalvm {
       else None
 
     val indices = releases0
-      .filter(release => release.tagName.startsWith("vm-"))
+      .filter(release => release.tagName.startsWith(s"jdk-$javaVersion"))
       .flatMap { release =>
-        val version = release.tagName.stripPrefix("vm-")
-        val assets  = Asset.releaseAssets(ghOrg, ghProj, ghToken, release.tagName)
+        val version         = release.tagName.stripPrefix("jdk-")
+        val assetNamePrefix = s"graalvm-community-jdk-${version}_"
+        val assets          = Asset.releaseAssets(ghOrg, ghProj, ghToken, release.tagName)
         assets
           .filter(asset => asset.name.startsWith(assetNamePrefix))
           .flatMap { asset =>
-            val name0 = asset.name.stripPrefix(assetNamePrefix)
-            val opt = for {
-              (os, rem)    <- osOpt(name0)
-              (arch, rem0) <- archOpt(rem)
-              ext <- Some(rem0)
-                .filter(_.startsWith(version + "."))
-                .map(_.stripPrefix(version + "."))
-              archiveType <- archiveTypeOpt(ext)
-            } yield Index(os, arch, name, version, archiveType + "+" + asset.downloadUrl)
-            opt.toSeq
+            val name0       = asset.name.stripPrefix(assetNamePrefix)
+            val nameGlobal  = "jdk@graalvm"
+            val nameVersion = s"jdk@graalvm-java$javaVersion"
+            val opt =
+              for {
+                (os, rem)    <- osOpt(name0)
+                (arch, rem0) <- archOpt(rem)
+                ext <- Some(rem0)
+                  .filter(_.startsWith("."))
+                  .map(_.stripPrefix("."))
+                archiveType <- archiveTypeOpt(ext)
+              } yield Seq(
+                Index(os, arch, nameGlobal, version, archiveType + "+" + asset.downloadUrl),
+                Index(os, arch, nameVersion, version, archiveType + "+" + asset.downloadUrl)
+              )
+            opt.toSeq.flatten
           }
       }
 

--- a/src/GraalvmLegacy.scala
+++ b/src/GraalvmLegacy.scala
@@ -1,0 +1,81 @@
+object GraalvmLegacy {
+
+  def fullIndex(ghToken: String): Index = {
+    val graalvmIndex0      = index(ghToken, "8")
+    val graalvmJdk11Index0 = index(ghToken, "11")
+    val graalvmJdk16Index0 = index(ghToken, "16")
+    val graalvmJdk17Index0 = index(ghToken, "17")
+    val graalvmJdk19Index0 = index(ghToken, "19")
+    graalvmIndex0 + graalvmJdk11Index0 + graalvmJdk16Index0 + graalvmJdk17Index0 + graalvmJdk19Index0
+  }
+
+  def index(
+    ghToken: String,
+    javaVersion: String,
+    javaVersionInName: java.lang.Boolean = null
+  ): Index = {
+
+    val javaVersionInName0 = Option(javaVersionInName)
+      .map(x => x: Boolean)
+      .getOrElse(javaVersion != "8")
+    val name =
+      if (javaVersionInName0)
+        s"jdk@graalvm-java$javaVersion"
+      else
+        "jdk@graalvm"
+
+    val ghOrg  = "graalvm"
+    val ghProj = "graalvm-ce-builds"
+    val releases0 = Release.releaseIds(ghOrg, ghProj, ghToken)
+      .filter(!_.prerelease)
+
+    val assetNamePrefix = s"graalvm-ce-java$javaVersion-"
+
+    def osOpt(input: String): Option[(String, String)] =
+      if (input.startsWith("linux-"))
+        Some(("linux", input.stripPrefix("linux-")))
+      else if (input.startsWith("darwin-"))
+        Some(("darwin", input.stripPrefix("darwin-")))
+      else if (input.startsWith("windows-"))
+        Some(("windows", input.stripPrefix("windows-")))
+      else
+        None
+
+    def archOpt(input: String): Option[(String, String)] =
+      if (input.startsWith("amd64-"))
+        Some(("amd64", input.stripPrefix("amd64-")))
+      else if (input.startsWith("aarch64-"))
+        Some(("arm64", input.stripPrefix("aarch64-")))
+      else
+        None
+
+    def archiveTypeOpt(input: String): Option[String] =
+      if (input == "zip") Some("zip")
+      else if (input == "tar.gz") Some("tgz")
+      else None
+
+    val indices = releases0
+      .filter(release => release.tagName.startsWith("vm-"))
+      .flatMap { release =>
+        val version = release.tagName.stripPrefix("vm-")
+        val assets  = Asset.releaseAssets(ghOrg, ghProj, ghToken, release.tagName)
+        assets
+          .filter(asset => asset.name.startsWith(assetNamePrefix))
+          .flatMap { asset =>
+            val name0 = asset.name.stripPrefix(assetNamePrefix)
+            val opt = for {
+              (os, rem)    <- osOpt(name0)
+              (arch, rem0) <- archOpt(rem)
+              ext <- Some(rem0)
+                .filter(_.startsWith(version + "."))
+                .map(_.stripPrefix(version + "."))
+              archiveType <- archiveTypeOpt(ext)
+            } yield Index(os, arch, name, version, archiveType + "+" + asset.downloadUrl)
+            opt.toSeq
+          }
+      }
+
+    indices.foldLeft(Index.empty)(_ + _)
+  }
+
+}


### PR DESCRIPTION
I guess users using only `graalvm` won't get new version until 21/22, but I think it's worth it - the support for that would require some new naming scheme (like adding `9999` before version to ensure it's the latest).