### PR TITLE
Add Oracle JVMs (JDK and GraalVM) to the Index

### DIFF
--- a/src/GenerateIndex.scala
+++ b/src/GenerateIndex.scala
@@ -13,12 +13,13 @@ object GenerateIndex {
     val correttoIndex0      = Corretto.fullIndex(GhToken.token)
     val graalvmLegacyIndex0 = GraalvmLegacy.fullIndex(GhToken.token)
     val graalvmIndex0       = Graalvm.fullIndex(GhToken.token)
+    val oracleIndex0        = OracleJDKs.index()
     val adoptIndex0         = Temurin.fullIndex(GhToken.token)
     val zuluIndex0          = Zulu.index()
     val libericaIndex0      = Liberica.index()
 
     val json =
-      (graalvmLegacyIndex0 + graalvmIndex0 + adoptIndex0 + zuluIndex0 + libericaIndex0 + correttoIndex0).json
+      (graalvmLegacyIndex0 + graalvmIndex0 + oracleIndex0 + adoptIndex0 + zuluIndex0 + libericaIndex0 + correttoIndex0).json
     val dest = os.Path(output, os.pwd)
     os.write.over(dest, json)
     System.err.println(s"Wrote $dest")

--- a/src/OracleJDKs.scala
+++ b/src/OracleJDKs.scala
@@ -1,0 +1,71 @@
+import sttp.client3.quick._
+
+object OracleJDKs {
+  final case class OracleJdkParams(
+    indexOs: String,
+    indexArch: String,
+    indexJdkName: String,
+    jdkVersion: String,
+    indexArchiveType: String
+  ) {
+    lazy val url =
+      uri"https://download.oracle.com/$indexJdkName/$jdkVersion/latest/$jdkName-${jdkVersion}_$os-${indexArch}_bin.$ext"
+
+    lazy val jdkName = indexJdkName match {
+      case "java"    => "jdk"
+      case "graalvm" => "graalvm-jdk"
+    }
+
+    lazy val os = indexOs match {
+      case "linux"   => "linux"
+      case "darwin"  => "macos"
+      case "windows" => "windows"
+      case x         => x
+    }
+
+    lazy val arch = indexArch match {
+      case "aarch64" => "arm64"
+      case "x64"     => "amd64"
+      case _         => ???
+    }
+
+    lazy val ext = indexArchiveType match {
+      case "tgz" => "tar.gz"
+      case x     => x
+    }
+
+    def index(url: String) =
+      Index(os, arch, s"$jdkName@oracle", jdkVersion, url)
+  }
+
+  def index(): Index = {
+    val oses     = Seq("darwin", "linux", "windows")
+    val jdks     = Seq("17", "21")
+    val jdkNames = Seq("java", "graalvm")
+    val allParams = for {
+      os      <- oses
+      cpu     <- if (os == "windows") Seq("x64") else Seq("x64", "aarch64")
+      jdk     <- jdks
+      jdkName <- jdkNames
+      ext = if (os == "windows") "zip" else "tgz"
+    } yield OracleJdkParams(os, cpu, jdkName, jdk, ext)
+
+    allParams.map(params =>
+      val resp = quickRequest.get(params.url)
+        .followRedirects(false) // invalid URL => 301 + redirect to 200; keep the 301
+        .response(ignore)       // don't download and hang on 200s
+        .send(backend)
+
+      if (resp.code.isSuccess) {
+        System.err.println(s"Valid url (status code ${resp.code}): ${params.url}")
+        params.index(params.url.toString)
+      }
+      else {
+        System.err.println(s"Invalid url (status code ${resp.code}): ${params.url}")
+        Index.empty
+      }
+    ).filterNot(_ != Index.empty)
+      .foldLeft(Index.empty)(_ + _)
+  }
+
+}


### PR DESCRIPTION
It generates the index and checks URLs for both JDK and GraalVM distributions.

Below is the index only for the changes:

```json
{
  "linux": {
    "amd64": {
      "graalvm-jdk@oracle": {
        "17": "https://download.oracle.com/graalvm/17/latest/graalvm-jdk-17_linux-x64_bin.tar.gz",
        "21": "https://download.oracle.com/graalvm/21/latest/graalvm-jdk-21_linux-x64_bin.tar.gz"
      },
      "jdk@oracle": {
        "17": "https://download.oracle.com/java/17/latest/jdk-17_linux-x64_bin.tar.gz",
        "21": "https://download.oracle.com/java/21/latest/jdk-21_linux-x64_bin.tar.gz"
      }
    },
    "arm64": {
      "graalvm-jdk@oracle": {
        "17": "https://download.oracle.com/graalvm/17/latest/graalvm-jdk-17_linux-aarch64_bin.tar.gz",
        "21": "https://download.oracle.com/graalvm/21/latest/graalvm-jdk-21_linux-aarch64_bin.tar.gz"
      },
      "jdk@oracle": {
        "17": "https://download.oracle.com/java/17/latest/jdk-17_linux-aarch64_bin.tar.gz",
        "21": "https://download.oracle.com/java/21/latest/jdk-21_linux-aarch64_bin.tar.gz"
      }
    }
  },
  "macos": {
    "amd64": {
      "graalvm-jdk@oracle": {
        "17": "https://download.oracle.com/graalvm/17/latest/graalvm-jdk-17_macos-x64_bin.tar.gz",
        "21": "https://download.oracle.com/graalvm/21/latest/graalvm-jdk-21_macos-x64_bin.tar.gz"
      },
      "jdk@oracle": {
        "17": "https://download.oracle.com/java/17/latest/jdk-17_macos-x64_bin.tar.gz",
        "21": "https://download.oracle.com/java/21/latest/jdk-21_macos-x64_bin.tar.gz"
      }
    },
    "arm64": {
      "graalvm-jdk@oracle": {
        "17": "https://download.oracle.com/graalvm/17/latest/graalvm-jdk-17_macos-aarch64_bin.tar.gz",
        "21": "https://download.oracle.com/graalvm/21/latest/graalvm-jdk-21_macos-aarch64_bin.tar.gz"
      },
      "jdk@oracle": {
        "17": "https://download.oracle.com/java/17/latest/jdk-17_macos-aarch64_bin.tar.gz",
        "21": "https://download.oracle.com/java/21/latest/jdk-21_macos-aarch64_bin.tar.gz"
      }
    }
  },
  "windows": {
    "amd64": {
      "graalvm-jdk@oracle": {
        "17": "https://download.oracle.com/graalvm/17/latest/graalvm-jdk-17_windows-x64_bin.zip",
        "21": "https://download.oracle.com/graalvm/21/latest/graalvm-jdk-21_windows-x64_bin.zip"
      },
      "jdk@oracle": {
        "17": "https://download.oracle.com/java/17/latest/jdk-17_windows-x64_bin.zip",
        "21": "https://download.oracle.com/java/21/latest/jdk-21_windows-x64_bin.zip"
      }
    }
  }
}
```