### PR TITLE
Write per OS / architecture indices too

### DIFF
--- a/src/GenerateIndex.scala
+++ b/src/GenerateIndex.scala
@@ -8,7 +8,9 @@ object GenerateIndex {
 
   def main(args: Array[String]): Unit = {
 
-    val output = "index.json"
+    val baseName = "index"
+
+    val dest = os.pwd / s"$baseName.json"
 
     val correttoIndex0      = Corretto.fullIndex(GhToken.token)
     val graalvmLegacyIndex0 = GraalvmLegacy.fullIndex(GhToken.token)
@@ -18,9 +20,15 @@ object GenerateIndex {
     val zuluIndex0          = Zulu.index()
     val libericaIndex0      = Liberica.index()
 
-    val json =
-      (graalvmLegacyIndex0 + graalvmIndex0 + oracleIndex0 + adoptIndex0 + zuluIndex0 + libericaIndex0 + correttoIndex0).json
-    val dest = os.Path(output, os.pwd)
+    val index = graalvmLegacyIndex0 +
+      graalvmIndex0 +
+      oracleIndex0 +
+      adoptIndex0 +
+      zuluIndex0 +
+      libericaIndex0 +
+      correttoIndex0
+
+    val json = index.json
     os.write.over(dest, json)
     System.err.println(s"Wrote $dest")
   }

--- a/src/GenerateIndex.scala
+++ b/src/GenerateIndex.scala
@@ -31,5 +31,12 @@ object GenerateIndex {
     val json = index.json
     os.write.over(dest, json)
     System.err.println(s"Wrote $dest")
+
+    for (((os0, arch), osArchIndex) <- index.osArchIndices.toVector.sortBy(_._1)) {
+      val dest0 = os.pwd / s"$baseName-$os0-$arch.json"
+      val json0 = osArchIndex.json
+      os.write.over(dest0, json0)
+      System.err.println(s"Wrote $dest0")
+    }
   }
 }

--- a/src/Index.scala
+++ b/src/Index.scala
@@ -19,6 +19,15 @@ final case class Index(map: Map[String, Map[String, Map[String, Map[String, Stri
 
   def json: String =
     Index.json4(map).render(indent = 2)
+
+  def osArchIndices: Map[(String, String), OsArchIndex] =
+    map.flatMap {
+      case (os, osMap) =>
+        osMap.map {
+          case (arch, osArchMap) =>
+            ((os, arch), OsArchIndex(osArchMap))
+        }
+    }
 }
 
 object Index {
@@ -149,7 +158,7 @@ object Index {
       ujson.Obj(l.head, l.tail: _*)
   }
 
-  private def json2(
+  def json2(
     map: Map[String, Map[String, String]]
   ) = {
     val l = map

--- a/src/Index.scala
+++ b/src/Index.scala
@@ -14,6 +14,25 @@ final case class Index(map: Map[String, Map[String, Map[String, Map[String, Stri
       }
     )
 
+  def +(other: Index): Index =
+    Index(Index.merge4(map, other.map))
+
+  def json: String =
+    Index.json4(map).render(indent = 2)
+}
+
+object Index {
+  def empty: Index =
+    Index(Map.empty)
+  def apply(
+    os: String,
+    architecture: String,
+    jdkName: String,
+    jdkVersion: String,
+    url: String
+  ): Index =
+    Index(Map(os -> Map(architecture -> Map(jdkName -> Map(jdkVersion -> url)))))
+
   private def merge4(
     a: Map[String, Map[String, Map[String, Map[String, String]]]],
     b: Map[String, Map[String, Map[String, Map[String, String]]]]
@@ -98,9 +117,6 @@ final case class Index(map: Map[String, Map[String, Map[String, Map[String, Stri
       }
       .toMap
 
-  def +(other: Index): Index =
-    Index(merge4(map, other.map))
-
   private def json4(
     map: Map[String, Map[String, Map[String, Map[String, String]]]]
   ) = {
@@ -165,19 +181,4 @@ final case class Index(map: Map[String, Map[String, Map[String, Map[String, Stri
       ujson.Obj(l.head, l.tail: _*)
   }
 
-  def json: String =
-    json4(map).render(indent = 2)
-}
-
-object Index {
-  def empty: Index =
-    Index(Map.empty)
-  def apply(
-    os: String,
-    architecture: String,
-    jdkName: String,
-    jdkVersion: String,
-    url: String
-  ): Index =
-    Index(Map(os -> Map(architecture -> Map(jdkName -> Map(jdkVersion -> url)))))
 }

--- a/src/OsArchIndex.scala
+++ b/src/OsArchIndex.scala
@@ -1,0 +1,4 @@
+final case class OsArchIndex(map: Map[String, Map[String, String]]) {
+  def json: String =
+    Index.json2(map).render(indent = 2)
+}


### PR DESCRIPTION
The index grows bigger, and users on a given machine only look at one specific OS and one specific architecture in the index. Better make users only download entries for the OS and architecture they're interested in.