### PR TITLE
Bump libs/scala-cli. Fix deprecation.

### DIFF
--- a/scala-cli.sh
+++ b/scala-cli.sh
@@ -7,7 +7,7 @@
 
 set -eu
 
-SCALA_CLI_VERSION="1.0.4"
+SCALA_CLI_VERSION="1.1.3"
 
 GH_ORG="VirtusLab"
 GH_NAME="scala-cli"

--- a/src/GenerateIndex.scala
+++ b/src/GenerateIndex.scala
@@ -1,7 +1,7 @@
 //> using scala 3
-//> using dep com.softwaremill.sttp.client3::core::3.9.3
-//> using dep com.lihaoyi::ujson::3.2.0
-//> using dep com.lihaoyi::os-lib::0.9.3
+//> using dep com.softwaremill.sttp.client3::core:3.9.3
+//> using dep com.lihaoyi::ujson:3.2.0
+//> using dep com.lihaoyi::os-lib:0.9.3
 //> using options -Wunused:all -deprecation
 
 object GenerateIndex {

--- a/src/GenerateIndex.scala
+++ b/src/GenerateIndex.scala
@@ -1,7 +1,7 @@
 //> using scala 3
-//> using dep com.softwaremill.sttp.client3::core:3.9.0
-//> using dep com.lihaoyi::ujson:3.1.3
-//> using dep com.lihaoyi::os-lib:0.9.1
+//> using dep com.softwaremill.sttp.client3::core::3.9.3
+//> using dep com.lihaoyi::ujson::3.2.0
+//> using dep com.lihaoyi::os-lib::0.9.3
 //> using options -Wunused:all -deprecation
 
 object GenerateIndex {

--- a/src/Index.scala
+++ b/src/Index.scala
@@ -139,7 +139,7 @@ object Index {
     if (l.isEmpty)
       ujson.Obj()
     else
-      ujson.Obj(l.head, l.tail: _*)
+      ujson.Obj(l.head, l.tail*)
   }
 
   private def json3(
@@ -155,7 +155,7 @@ object Index {
     if (l.isEmpty)
       ujson.Obj()
     else
-      ujson.Obj(l.head, l.tail: _*)
+      ujson.Obj(l.head, l.tail*)
   }
 
   def json2(
@@ -171,7 +171,7 @@ object Index {
     if (l.isEmpty)
       ujson.Obj()
     else
-      ujson.Obj(l.head, l.tail: _*)
+      ujson.Obj(l.head, l.tail*)
   }
 
   private def json1(
@@ -187,7 +187,7 @@ object Index {
     if (l.isEmpty)
       ujson.Obj()
     else
-      ujson.Obj(l.head, l.tail: _*)
+      ujson.Obj(l.head, l.tail*)
   }
 
 }


### PR DESCRIPTION
Bump libs and scala-cli.

Fix deprecation:

```
[warn] ./src/Index.scala:142:33
[warn] The syntax `x: _*` is no longer supported for vararg splices; use `x*` instead
[warn] This construct can be rewritten automatically under -rewrite -source 3.4-migration.
[warn]       ujson.Obj(l.head, l.tail: _*)
...
```