### PR TITLE
fix: use filter instead of filterNot

### DIFF
--- a/src/Oracle.scala
+++ b/src/Oracle.scala
@@ -66,7 +66,7 @@ object Oracle {
           Index.empty
         }
       }
-      .filterNot(_ != Index.empty)
+      .filter(_ != Index.empty)
       .foldLeft(Index.empty)(_ + _)
   }
 


### PR DESCRIPTION
Looks like the logic here was mixed up and instead we were filtering
everything that wasn't empty instead of the empty one. This changes that
and ensures that the oracle jvms actually get written in the index.json.
