### PR TITLE
Map correctly the Oracle JVMs to darwin index

### DIFF
--- a/src/Oracle.scala
+++ b/src/Oracle.scala
@@ -35,7 +35,7 @@ object Oracle {
     }
 
     def index(url: String) =
-      Index(os, arch, s"$jdkName@oracle", jdkVersion, url)
+      Index(indexOs, arch, s"$jdkName@oracle", jdkVersion, url)
   }
 
   def index(): Index = {


### PR DESCRIPTION
This fixes the Oracle JVMs for Mac that were added to "macos" index file instead of "darwin".
