### PR TITLE
Add pull request number and URL to job summary

### DIFF
--- a/.github/workflows/update-index.yml
+++ b/.github/workflows/update-index.yml
@@ -2,7 +2,7 @@ name: Update index
 on:
   push:
     branches:
-    - master
+      - master
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
@@ -29,5 +29,5 @@ jobs:
           title: Update index
       - name: Check Pull Request
         run: |
-          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
-          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}" >> $GITHUB_STEP_SUMMARY
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Add the PR number and URL to the job summary instead of job log.