### PR TITLE
Fix Oracle JDK index generation

### DIFF
--- a/src/Oracle.scala
+++ b/src/Oracle.scala
@@ -8,7 +8,7 @@ object Oracle {
     jdkVersion: String,
     indexArchiveType: String
   ) {
-    lazy val url =
+    lazy val url: sttp.model.Uri =
       uri"https://download.oracle.com/$indexJdkName/$jdkVersion/latest/$jdkName-${jdkVersion}_$os-${indexArch}_bin.$ext"
 
     lazy val jdkName = indexJdkName match {
@@ -35,7 +35,8 @@ object Oracle {
     }
 
     def index(url: String) =
-      Index(indexOs, arch, s"$jdkName@oracle", jdkVersion, url)
+      val indexUrl = s"$indexArchiveType+$url"
+      Index(indexOs, arch, s"jdk@$indexJdkName-oracle", jdkVersion, indexUrl)
   }
 
   def index(): Index = {


### PR DESCRIPTION
Found the issue that led to https://github.com/coursier/coursier/issues/2952.

The Oracle index currently generates:

```json
{
"graalvm-jdk@oracle": {
  "17": "https://download.oracle.com/graalvm/17/latest/graalvm-jdk-17_macos-x64_bin.tar.gz",
  "21": "https://download.oracle.com/graalvm/21/latest/graalvm-jdk-21_macos-x64_bin.tar.gz"
```

While the correct way is as now:

```json
{
"jdk@graalvm-oracle": {
        "17": "tgz+https://download.oracle.com/graalvm/17/latest/graalvm-jdk-17_macos-x64_bin.tar.gz",
        "21": "tgz+https://download.oracle.com/graalvm/21/latest/graalvm-jdk-21_macos-x64_bin.tar.gz"
      },
"jdk@java-oracle": {
        "17": "tgz+https://download.oracle.com/java/17/latest/jdk-17_macos-x64_bin.tar.gz",
        "21": "tgz+https://download.oracle.com/java/21/latest/jdk-21_macos-x64_bin.tar.gz"
      }
...
```

Sorry about the hassle.