### PR TITLE
refactor: start typing all the Strings

### DIFF
--- a/src/Corretto.scala
+++ b/src/Corretto.scala
@@ -1,4 +1,5 @@
 import sttp.client3.quick._
+import Index.Os
 
 /*
 - Latest Corretto binaries are listed at https://docs.aws.amazon.com/corretto/
@@ -17,14 +18,14 @@ import sttp.client3.quick._
 object Corretto {
 
   final case class CorrettoParams(
-    indexOs: String,
+    indexOs: Os,
     indexArch: String,
     indexArchiveType: String
   ) {
     lazy val os = indexOs match {
-      case "linux-musl" => "linux_musl"
-      case "darwin"     => "macosx"
-      case x            => x
+      case Os("linux-musl") => "linux_musl"
+      case Os("darwin")     => "macosx"
+      case x                => x
     }
 
     lazy val ext = indexArchiveType match {
@@ -39,8 +40,8 @@ object Corretto {
     }
 
     lazy val jdk = indexOs match {
-      case "windows" => "-jdk"
-      case _         => ""
+      case Os("windows") => "-jdk"
+      case _             => ""
     }
 
     def index(jdkTagVersion: String, url: String): Index =
@@ -70,12 +71,12 @@ object Corretto {
     releases0
       .flatMap { release =>
         // See https://github.com/corretto/corretto-17/releases/tag/17.0.6.10.1 for os/cpu combinations
-        val oses = Seq("darwin", "linux", "windows", "alpine-linux")
-        val cpus = Seq("amd64", "arm64")
+        val oses: Seq[Os] = Seq(Os("darwin"), Os("linux"), Os("windows"), Os("alpine-linux"))
+        val cpus          = Seq("amd64", "arm64")
         val allParams = for {
           os  <- oses
           cpu <- cpus
-          ext = if (os == "windows") "zip" else "tgz"
+          ext = if (os == Os("windows")) "zip" else "tgz"
         } yield CorrettoParams(os, cpu, ext)
 
         allParams

--- a/src/GenerateIndex.scala
+++ b/src/GenerateIndex.scala
@@ -1,5 +1,5 @@
 //> using scala 3
-//> using dep com.softwaremill.sttp.client3::core:3.9.3
+//> using dep com.softwaremill.sttp.client3::core:3.9.5
 //> using dep com.lihaoyi::ujson:3.2.0
 //> using dep com.lihaoyi::os-lib:0.9.3
 //> using options -Wunused:all -deprecation

--- a/src/Graalvm.scala
+++ b/src/Graalvm.scala
@@ -1,3 +1,5 @@
+import Index.Os
+
 object Graalvm {
 
   def fullIndex(ghToken: String): Index = {
@@ -17,13 +19,13 @@ object Graalvm {
     val releases0 = Release.releaseIds(ghOrg, ghProj, ghToken)
       .filter(!_.prerelease)
 
-    def osOpt(input: String): Option[(String, String)] =
+    def osOpt(input: String): Option[(Os, String)] =
       if (input.startsWith("linux-"))
-        Some(("linux", input.stripPrefix("linux-")))
+        Some((Os("linux"), input.stripPrefix("linux-")))
       else if (input.startsWith("macos-"))
-        Some(("darwin", input.stripPrefix("macos-")))
+        Some((Os("darwin"), input.stripPrefix("macos-")))
       else if (input.startsWith("windows-"))
-        Some(("windows", input.stripPrefix("windows-")))
+        Some((Os("windows"), input.stripPrefix("windows-")))
       else
         None
 

--- a/src/GraalvmLegacy.scala
+++ b/src/GraalvmLegacy.scala
@@ -1,3 +1,5 @@
+import Index.Os
+
 object GraalvmLegacy {
 
   def fullIndex(ghToken: String): Index = {
@@ -31,13 +33,13 @@ object GraalvmLegacy {
 
     val assetNamePrefix = s"graalvm-ce-java$javaVersion-"
 
-    def osOpt(input: String): Option[(String, String)] =
+    def osOpt(input: String): Option[(Os, String)] =
       if (input.startsWith("linux-"))
-        Some(("linux", input.stripPrefix("linux-")))
+        Some((Os("linux"), input.stripPrefix("linux-")))
       else if (input.startsWith("darwin-"))
-        Some(("darwin", input.stripPrefix("darwin-")))
+        Some((Os("darwin"), input.stripPrefix("darwin-")))
       else if (input.startsWith("windows-"))
-        Some(("windows", input.stripPrefix("windows-")))
+        Some((Os("windows"), input.stripPrefix("windows-")))
       else
         None
 

--- a/src/IbmSemeru.scala
+++ b/src/IbmSemeru.scala
@@ -1,3 +1,5 @@
+import Index.Os
+
 object IbmSemeru {
 
   def fullIndex(ghToken: String): Index = {
@@ -17,13 +19,13 @@ object IbmSemeru {
     val releases0 = Release.releaseIds(ghOrg, ghProj, ghToken)
       .filter(!_.prerelease)
 
-    def osOpt(input: String): Option[(String, String)] =
+    def osOpt(input: String): Option[(Os, String)] =
       input match
-        case input if input.startsWith("linux") => Some(("linux", input.stripPrefix("linux_")))
-        case input if input.startsWith("mac")   => Some(("darwin", input.stripPrefix("mac_")))
+        case input if input.startsWith("linux") => Some((Os("linux"), input.stripPrefix("linux_")))
+        case input if input.startsWith("mac")   => Some((Os("darwin"), input.stripPrefix("mac_")))
         case input if input.startsWith("windows") =>
-          Some(("windows", input.stripPrefix("windows_")))
-        case input if input.startsWith("aix") => Some(("aix", input.stripPrefix("aix_")))
+          Some((Os("windows"), input.stripPrefix("windows_")))
+        case input if input.startsWith("aix") => Some((Os("aix"), input.stripPrefix("aix_")))
         case _                                => None
 
     def archOpt(input: String): Option[(String, String)] =

--- a/src/Index.scala
+++ b/src/Index.scala
@@ -1,4 +1,6 @@
-final case class Index(map: Map[String, Map[String, Map[String, Map[String, String]]]]) {
+import Index.Os
+
+final case class Index(map: Map[Os, Map[String, Map[String, Map[String, String]]]]) {
 
   def mapJdkName(f: String => String): Index =
     Index(
@@ -20,7 +22,7 @@ final case class Index(map: Map[String, Map[String, Map[String, Map[String, Stri
   def json: String =
     Index.json4(map).render(indent = 2)
 
-  def osArchIndices: Map[(String, String), OsArchIndex] =
+  def osArchIndices: Map[(Os, String), OsArchIndex] =
     map.flatMap {
       case (os, osMap) =>
         osMap.map {
@@ -31,10 +33,19 @@ final case class Index(map: Map[String, Map[String, Map[String, Map[String, Stri
 }
 
 object Index {
+
+  opaque type Os = String
+  object Os:
+    def apply(value: String): Os        = value
+    def unapply(os: Os): Option[String] = Some(os.toString())
+
+    given Ordering[Os] with
+      def compare(a: Os, b: Os) = a.compareTo(b)
+
   def empty: Index =
     Index(Map.empty)
   def apply(
-    os: String,
+    os: Os,
     architecture: String,
     jdkName: String,
     jdkVersion: String,
@@ -43,9 +54,9 @@ object Index {
     Index(Map(os -> Map(architecture -> Map(jdkName -> Map(jdkVersion -> url)))))
 
   private def merge4(
-    a: Map[String, Map[String, Map[String, Map[String, String]]]],
-    b: Map[String, Map[String, Map[String, Map[String, String]]]]
-  ): Map[String, Map[String, Map[String, Map[String, String]]]] =
+    a: Map[Os, Map[String, Map[String, Map[String, String]]]],
+    b: Map[Os, Map[String, Map[String, Map[String, String]]]]
+  ): Map[Os, Map[String, Map[String, Map[String, String]]]] =
     (a.keySet ++ b.keySet)
       .iterator
       .map { key =>
@@ -127,14 +138,14 @@ object Index {
       .toMap
 
   private def json4(
-    map: Map[String, Map[String, Map[String, Map[String, String]]]]
+    map: Map[Os, Map[String, Map[String, Map[String, String]]]]
   ) = {
     val l = map
       .toVector
       .sortBy(_._1)
       .map {
-        case (k, m) =>
-          k -> json3(m)
+        case (os, m) =>
+          os.toString() -> json3(m)
       }
     if (l.isEmpty)
       ujson.Obj()

--- a/src/Liberica.scala
+++ b/src/Liberica.scala
@@ -1,5 +1,6 @@
 import sttp.client3.quick._
 import scala.util.control.NonFatal
+import Index.Os
 
 object Liberica {
 
@@ -19,9 +20,9 @@ object Liberica {
 
     def jdkVersion: String = s"$featureVersion.$patchVersion.$updateVersion"
 
-    def indexOs = os match {
-      case "macos" => "darwin"
-      case x       => x
+    def indexOs: Os = os match {
+      case "macos" => Os("darwin")
+      case x       => Os(x)
     }
     def indexArchOpt = (architecture, bitness) match {
       case ("arm", 32) => Some("arm")

--- a/src/Oracle.scala
+++ b/src/Oracle.scala
@@ -1,8 +1,9 @@
 import sttp.client3.quick._
+import Index.Os
 
 object Oracle {
   final case class Params(
-    indexOs: String,
+    indexOs: Os,
     indexArch: String,
     indexJdkName: String,
     jdkVersion: String,
@@ -17,10 +18,10 @@ object Oracle {
     }
 
     lazy val os = indexOs match {
-      case "linux"   => "linux"
-      case "darwin"  => "macos"
-      case "windows" => "windows"
-      case x         => x
+      case Os("linux")   => "linux"
+      case Os("darwin")  => "macos"
+      case Os("windows") => "windows"
+      case x             => x
     }
 
     lazy val arch = indexArch match {
@@ -40,15 +41,15 @@ object Oracle {
   }
 
   def index(): Index = {
-    val oses     = Seq("darwin", "linux", "windows")
+    val oses     = Seq(Os("darwin"), Os("linux"), Os("windows"))
     val jdks     = Seq("17", "21")
     val jdkNames = Seq("java", "graalvm")
     val allParams = for {
       os      <- oses
-      cpu     <- if (os == "windows") Seq("x64") else Seq("x64", "aarch64")
+      cpu     <- if (os == Os("windows")) Seq("x64") else Seq("x64", "aarch64")
       jdk     <- jdks
       jdkName <- jdkNames
-      ext = if (os == "windows") "zip" else "tgz"
+      ext = if (os == Os("windows")) "zip" else "tgz"
     } yield Params(os, cpu, jdkName, jdk, ext)
 
     allParams

--- a/src/Temurin.scala
+++ b/src/Temurin.scala
@@ -1,3 +1,5 @@
+import Index.Os
+
 object Temurin {
 
   def fullIndex(ghToken: String): Index = {
@@ -57,17 +59,17 @@ object Temurin {
           k -> input.stripPrefix(v)
       }
 
-    def osOpt(input: String): Option[(String, String)] =
+    def osOpt(input: String): Option[(Os, String)] =
       if (input.startsWith("linux_"))
-        Some(("linux", input.stripPrefix("linux_")))
+        Some((Os("linux"), input.stripPrefix("linux_")))
       else if (input.startsWith("alpine-linux_"))
-        Some(("alpine-linux", input.stripPrefix("alpine-linux_")))
+        Some((Os("alpine-linux"), input.stripPrefix("alpine-linux_")))
       else if (input.startsWith("mac_"))
-        Some(("darwin", input.stripPrefix("mac_")))
+        Some((Os("darwin"), input.stripPrefix("mac_")))
       else if (input.startsWith("windows_"))
-        Some(("windows", input.stripPrefix("windows_")))
+        Some((Os("windows"), input.stripPrefix("windows_")))
       else if (input.startsWith("aix_"))
-        Some(("aix", input.stripPrefix("aix_")))
+        Some((Os("aix"), input.stripPrefix("aix_")))
       else
         None
 

--- a/src/Zulu.scala
+++ b/src/Zulu.scala
@@ -1,10 +1,11 @@
-import sttp.client3.quick._
+import Index.Os
+import sttp.client3.quick.*
 
 import scala.math.Ordering.Implicits.seqOrdering
 
 object Zulu {
   final case class ZuluParams(
-    indexOs: String,
+    indexOs: Os,
     indexArch: String,
     indexArchiveType: String,
     bundleType: String = "jdk",
@@ -14,9 +15,9 @@ object Zulu {
       uri"https://api.azul.com/zulu/download/community/v1.0/bundles/?os=$os&arch=$arch&hw_bitness=$bitness&bundle_type=$bundleType&ext=$ext&release_status=$releaseStatus&javafx=false"
 
     lazy val os = indexOs match {
-      case "linux-musl" => "linux_musl"
-      case "darwin"     => "macos"
-      case x            => x
+      case Os("linux-musl") => "linux_musl"
+      case Os("darwin")     => "macos"
+      case x                => x
     }
 
     lazy val (arch, bitness) = indexArch match {
@@ -46,13 +47,14 @@ object Zulu {
 
   def index(): Index = {
 
-    val oses        = Seq("darwin", "linux", "windows", "linux-musl") // Add "solaris", "qnx"?
+    val oses =
+      Seq(Os("darwin"), Os("linux"), Os("windows"), Os("linux-musl")) // Add "solaris", "qnx"?
     val cpus        = Seq("x86", "amd64", "arm", "arm64", "ppc64")
     val bundleTypes = Seq("jdk", "jre")
     val allParams = for {
       os  <- oses
       cpu <- cpus
-      ext = if (os == "windows") "zip" else "tgz"
+      ext = if (os == Os("windows")) "zip" else "tgz"
       bundleType <- bundleTypes
     } yield ZuluParams(os, cpu, ext, bundleType = bundleType)
 


### PR DESCRIPTION
This is sort of a proposal. Following the comment in
https://github.com/coursier/jvm-index/pull/243#issuecomment-2007605083
by @carlosedp I was going to try and write some docs on the actual
structure of the index, but right away hit on the fact that it's just
this:

```
final case class Index(map: Map[String, Map[String, Map[String, Map[String, String]]]]) {
```

It's pretty impossible to know what these `String`s all are so I figured
maybe it'd be good to start just typing this out a bit more. I used an
opaque type for `Os` here in hopes that it'd make things clearer a bit
throughout the code, and figured we could do that for all the `String`s
in the `Index`, but wanted to see what it would be like to at least do
one of them first. Thoughts on this?
