### PR TITLE
Pad versions when needed

### DIFF
--- a/.github/workflows/update-index.yml
+++ b/.github/workflows/update-index.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - pad-versions
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
@@ -19,7 +20,12 @@ jobs:
       - run: ./scala-cli.sh .
         env:
           GH_TOKEN: ${{ secrets.INDEX_GITHUB_TOKEN }}
+
+      - name: Print diff
+        run: git diff --color
+
       - name: Create Pull Request
+        if: github.ref == 'refs/heads/master'
         id: cpr
         uses: peter-evans/create-pull-request@v7.0.5
         with:
@@ -28,6 +34,7 @@ jobs:
           delete-branch: true
           title: Update index
       - name: Generate Job Summary
+        if: github.ref == 'refs/heads/master'
         run: |-
           PR_NUMBER=$(echo "${{ steps.cpr.outputs.pull-request-number }}")
           PR_URL=$(echo "${{ steps.cpr.outputs.pull-request-url }}")

--- a/src/coursier/jvmindex/Index.scala
+++ b/src/coursier/jvmindex/Index.scala
@@ -201,24 +201,35 @@ object Index {
       ujson.Obj(l.head, l.tail*)
   }
 
-  private def json1(
+  def json1(
     map: Map[String, String]
   ) = {
-    val l = map
+    val list = map
       .toVector
       .map {
         case (k, v) =>
           coursier.version.Version(k) -> v
       }
       .sortBy(_._1)
-      .map {
-        case (k, v) =>
-          k.repr -> ujson.Str(v)
-      }
-    if (l.isEmpty)
+    val requiredVersionLengthOpt = {
+      val versionLengthMap =
+        list.groupMap(_._1.items.length)(_ => ()).view.mapValues(_.length).toMap
+      if (versionLengthMap.size > 1) Some(versionLengthMap.maxBy(_._2)._1)
+      else None
+    }
+    val list0 = list.map {
+      case (k, v) =>
+        val version = requiredVersionLengthOpt match {
+          case Some(requiredVersionLength) if k.items.length < requiredVersionLength =>
+            k.repr + (".0" * (requiredVersionLength - k.items.length))
+          case _ => k.repr
+        }
+        version -> ujson.Str(v)
+    }
+    if (list0.isEmpty)
       ujson.Obj()
     else
-      ujson.Obj(l.head, l.tail*)
+      ujson.Obj(list0.head, list0.tail*)
   }
 
 }


### PR DESCRIPTION
So that we don't end up with "short" versions like "1.17" in the index, and coursier-jvm users can keep using things like "temurin:17" to mean the latest Temurin 17 JVM (rather than the first if the index has a "1.17" entry)