### PR TITLE
added Liberica NIK to the index

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,22 +8,23 @@ capabilities of coursier.
 
 ## Available JDKs
 
-| JDK | id in index |
-|--------|-----|
-| [Eclipse Temurin](https://adoptium.net/temurin/releases) (recommended / default) | `temurin` |
-| [GraalVM community](https://github.com/graalvm/graalvm-ce-builds/releases) | `graalvm-community` |
-| [Oracle JDKs](https://www.oracle.com/java/technologies/downloads/) | `oracle` |
-| [Azul Zulu](https://www.azul.com/downloads/?package=jdk#zulu) | `zulu` |
-| [bellsoft Liberica](https://bell-sw.com/pages/downloads/) | `liberica` |
-| [Amazon Corretto](https://aws.amazon.com/corretto/) | `corretto` |
-| [IBM Semeru](https://developer.ibm.com/languages/java/semeru-runtimes/) | `ibm-semeru` |
+| JDK                                                                                  | id in index         |
+| ------------------------------------------------------------------------------------ | ------------------- |
+| [Eclipse Temurin](https://adoptium.net/temurin/releases) (recommended / default)     | `temurin`           |
+| [GraalVM community](https://github.com/graalvm/graalvm-ce-builds/releases)           | `graalvm-community` |
+| [Oracle JDKs](https://www.oracle.com/java/technologies/downloads/)                   | `oracle`            |
+| [Azul Zulu](https://www.azul.com/downloads/?package=jdk#zulu)                        | `zulu`              |
+| [bellsoft Liberica](https://bell-sw.com/pages/downloads/)                            | `liberica`          |
+| [bellsoft Liberica Native Image Kit](https://bell-sw.com/liberica-native-image-kit/) | `liberica-nik`      |
+| [Amazon Corretto](https://aws.amazon.com/corretto/)                                  | `corretto`          |
+| [IBM Semeru](https://developer.ibm.com/languages/java/semeru-runtimes/)              | `ibm-semeru`        |
 
 ## Legacy JDKs
 
-| JDK | id in index |
-|--------|-----|
-| AdoptOpenJDK | `adopt` |
-| Merge of AdoptOpenJDK and Eclipse Temurin JDKs | `adoptium` |
+| JDK                                            | id in index |
+| ---------------------------------------------- | ----------- |
+| AdoptOpenJDK                                   | `adopt`     |
+| Merge of AdoptOpenJDK and Eclipse Temurin JDKs | `adoptium`  |
 
 ## Index structure
 
@@ -57,6 +58,7 @@ That index consists in 4 nested JSON objects, with the successive keys of these 
   - `jdk@temurin`
   - `jdk@graalvm-community`
   - `jdk@liberica`
+  - `jdk@liberica-nik`
   - `jdk@zulu`
   - `jdk@corretto`
   - `jdk@java-oracle`

--- a/index.json
+++ b/index.json
@@ -2611,6 +2611,162 @@
         "23.0.0": "zip+https://github.com/bell-sw/Liberica/releases/download/23+38/bellsoft-jdk23+38-macos-amd64-lite.zip",
         "23.0.1": "zip+https://github.com/bell-sw/Liberica/releases/download/23.0.1+13/bellsoft-jdk23.0.1+13-macos-amd64-lite.zip"
       },
+      "jdk@liberica-nik-core-java11": {
+        "11.0.11+9": "zip+https://download.bell-sw.com/vm/21.1.0/bellsoft-liberica-vm-core-openjdk11-21.1.0-macos-amd64.zip",
+        "11.0.12+7": "zip+https://download.bell-sw.com/vm/21.2.0/bellsoft-liberica-vm-core-openjdk11-21.2.0-macos-amd64.zip",
+        "11.0.13+8": "zip+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-core-openjdk11-21.3.0-macos-amd64.zip",
+        "11.0.14.1+1": "zip+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-core-openjdk11-21.3.1-macos-amd64.zip",
+        "11.0.15+10": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk11.0.15+10-21.3.2+1-macos-amd64.zip",
+        "11.0.15.1+2": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk11.0.15.1+2-21.3.2+2-macos-amd64.zip",
+        "11.0.16+8": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk11.0.16+8-21.3.3+1-macos-amd64.zip",
+        "11.0.16.1+1": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk11.0.16.1+1-21.3.3+2-macos-amd64.zip",
+        "11.0.17+7": "zip+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-core-openjdk11.0.17+7-21.3.3.1+1-macos-amd64.zip",
+        "11.0.18+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-core-openjdk11.0.18+10-22.3.1+1-macos-amd64.zip",
+        "11.0.19+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-core-openjdk11.0.19+7-22.3.2+1-macos-amd64.zip",
+        "11.0.20+8": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk11.0.20+8-22.3.3+1-macos-amd64.zip",
+        "11.0.20.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk11.0.20.1+1-22.3.3+2-macos-amd64.zip",
+        "11.0.21+10": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-core-openjdk11.0.21+9-22.3.4+1-macos-amd64.zip",
+        "11.0.22+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-core-openjdk11.0.22+12-22.3.5+1-macos-amd64.zip"
+      },
+      "jdk@liberica-nik-core-java17": {
+        "17.0.1+12": "zip+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-core-openjdk17-21.3.0-macos-amd64.zip",
+        "17.0.2+9": "zip+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-core-openjdk17-21.3.1-macos-amd64.zip",
+        "17.0.3+7": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk17.0.3+7-21.3.2+1-macos-amd64.zip",
+        "17.0.3.1+2": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk17.0.3.1+2-21.3.2+2-macos-amd64.zip",
+        "17.0.4+8": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk17.0.4+8-21.3.3+1-macos-amd64.zip",
+        "17.0.4.1+1": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk17.0.4.1+1-21.3.3+2-macos-amd64.zip",
+        "17.0.5+8": "zip+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-core-openjdk17.0.5+8-21.3.3.1+1-macos-amd64.zip",
+        "17.0.6+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-core-openjdk17.0.6+10-22.3.1+1-macos-amd64.zip",
+        "17.0.7+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-core-openjdk17.0.7+7-22.3.2+1-macos-amd64.zip",
+        "17.0.8+7": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk17.0.8+7-22.3.3+1-macos-amd64.zip",
+        "17.0.8.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk17.0.8.1+1-22.3.3+2-macos-amd64.zip",
+        "17.0.9+11": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-core-openjdk17.0.9+11-22.3.4+1-macos-amd64.zip",
+        "17.0.10+13": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-core-openjdk17.0.10+13-22.3.5+1-macos-amd64.zip",
+        "17.0.11+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-core-openjdk17.0.11+10-23.0.4+1-macos-amd64.zip",
+        "17.0.12+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-core-openjdk17.0.12+10-23.0.5+1-macos-amd64.zip",
+        "17.0.13+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-core-openjdk17.0.13+12-23.0.6+1-macos-amd64.zip"
+      },
+      "jdk@liberica-nik-core-java20": {
+        "20.0.1+10": "zip+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-core-openjdk20.0.1+10-23.0.0+1-macos-amd64.zip",
+        "20.0.2+10": "zip+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-core-openjdk20.0.2+10-23.0.1+1-macos-amd64.zip"
+      },
+      "jdk@liberica-nik-core-java21": {
+        "21+37.0.0": "zip+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-core-openjdk21+37-23.1.0+1-macos-amd64.zip",
+        "21.0.1+12": "zip+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-core-openjdk21.0.1+12-23.1.1+1-macos-amd64.zip",
+        "21.0.2+14": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-core-openjdk21.0.2+14-23.1.2+1-macos-amd64.zip",
+        "21.0.3+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-core-openjdk21.0.3+10-23.1.3+2-macos-amd64.zip",
+        "21.0.4+9": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-core-openjdk21.0.4+9-23.1.4+3-macos-amd64.zip",
+        "21.0.5+11": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-core-openjdk21.0.5+11-23.1.5+1-macos-amd64.zip"
+      },
+      "jdk@liberica-nik-full-java11": {
+        "11.0.14.1+1": "zip+https://download.bell-sw.com/vm/22.0.0.2/bellsoft-liberica-vm-full-openjdk11-22.0.0.2-macos-amd64.zip",
+        "11.0.15+10": "zip+https://download.bell-sw.com/vm/22.1.0/bellsoft-liberica-vm-full-openjdk11.0.15+10-22.1.0+1-macos-amd64.zip",
+        "11.0.15.1+2": "zip+https://download.bell-sw.com/vm/22.1.0/bellsoft-liberica-vm-full-openjdk11.0.15.1+2-22.1.0+2-macos-amd64.zip",
+        "11.0.16+8": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-full-openjdk11.0.16+8-22.2.0+2-macos-amd64.zip",
+        "11.0.16.1+1": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-full-openjdk11.0.16.1+1-22.2.0+3-macos-amd64.zip",
+        "11.0.17+7": "zip+https://download.bell-sw.com/vm/22.3.0/bellsoft-liberica-vm-full-openjdk11.0.17+7-22.3.0+2-macos-amd64.zip",
+        "11.0.18+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-full-openjdk11.0.18+10-22.3.1+1-macos-amd64.zip",
+        "11.0.19+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-full-openjdk11.0.19+7-22.3.2+1-macos-amd64.zip",
+        "11.0.20+8": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk11.0.20+8-22.3.3+1-macos-amd64.zip",
+        "11.0.20.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk11.0.20.1+1-22.3.3+2-macos-amd64.zip",
+        "11.0.21+10": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-full-openjdk11.0.21+9-22.3.4+1-macos-amd64.zip",
+        "11.0.22+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-full-openjdk11.0.22+12-22.3.5+1-macos-amd64.zip"
+      },
+      "jdk@liberica-nik-full-java17": {
+        "17.0.2+9": "zip+https://download.bell-sw.com/vm/22.0.0.2/bellsoft-liberica-vm-full-openjdk17-22.0.0.2-macos-amd64.zip",
+        "17.0.3+7": "zip+https://download.bell-sw.com/vm/22.1.0/bellsoft-liberica-vm-full-openjdk17.0.3+7-22.1.0+1-macos-amd64.zip",
+        "17.0.3.1+2": "zip+https://download.bell-sw.com/vm/22.1.0/bellsoft-liberica-vm-full-openjdk17.0.3.1+2-22.1.0+2-macos-amd64.zip",
+        "17.0.4+8": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-full-openjdk17.0.4+8-22.2.0+2-macos-amd64.zip",
+        "17.0.4.1+1": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-full-openjdk17.0.4.1+1-22.2.0+3-macos-amd64.zip",
+        "17.0.5+8": "zip+https://download.bell-sw.com/vm/22.3.0/bellsoft-liberica-vm-full-openjdk17.0.5+8-22.3.0+2-macos-amd64.zip",
+        "17.0.6+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-full-openjdk17.0.6+10-22.3.1+1-macos-amd64.zip",
+        "17.0.7+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-full-openjdk17.0.7+7-22.3.2+1-macos-amd64.zip",
+        "17.0.8+7": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk17.0.8+7-22.3.3+1-macos-amd64.zip",
+        "17.0.8.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk17.0.8.1+1-22.3.3+2-macos-amd64.zip",
+        "17.0.9+11": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-full-openjdk17.0.9+11-22.3.4+1-macos-amd64.zip",
+        "17.0.10+13": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-full-openjdk17.0.10+13-22.3.5+1-macos-amd64.zip",
+        "17.0.11+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-full-openjdk17.0.11+10-23.0.4+1-macos-amd64.zip",
+        "17.0.12+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-full-openjdk17.0.12+10-23.0.5+1-macos-amd64.zip",
+        "17.0.13+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-full-openjdk17.0.13+12-23.0.6+1-macos-amd64.zip"
+      },
+      "jdk@liberica-nik-full-java20": {
+        "20.0.1+10": "zip+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-full-openjdk20.0.1+10-23.0.0+1-macos-amd64.zip",
+        "20.0.2+10": "zip+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-full-openjdk20.0.2+10-23.0.1+1-macos-amd64.zip"
+      },
+      "jdk@liberica-nik-full-java21": {
+        "21+37.0.0": "zip+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-full-openjdk21+37-23.1.0+1-macos-amd64.zip",
+        "21.0.1+12": "zip+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-full-openjdk21.0.1+12-23.1.1+1-macos-amd64.zip",
+        "21.0.2+14": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-full-openjdk21.0.2+14-23.1.2+1-macos-amd64.zip",
+        "21.0.3+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-full-openjdk21.0.3+10-23.1.3+2-macos-amd64.zip",
+        "21.0.4+9": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-full-openjdk21.0.4+9-23.1.4+3-macos-amd64.zip",
+        "21.0.5+11": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-full-openjdk21.0.5+11-23.1.5+1-macos-amd64.zip"
+      },
+      "jdk@liberica-nik-full-java22": {
+        "22+37.0.0": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.0+1-22+37/bellsoft-liberica-vm-full-openjdk22+37-24.0.0+1-macos-amd64.zip",
+        "22.0.1+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.1+1-22.0.1+10/bellsoft-liberica-vm-full-openjdk22.0.1+10-24.0.1+1-macos-amd64.zip",
+        "22.0.2+11": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.2+1-22.0.2+11/bellsoft-liberica-vm-full-openjdk22.0.2+11-24.0.2+1-macos-amd64.zip"
+      },
+      "jdk@liberica-nik-full-java23": {
+        "23+38": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.0+1-23+38/bellsoft-liberica-vm-full-openjdk23+38-24.1.0+1-macos-amd64.zip",
+        "23.0.1+13": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.1+1-23.0.1+13/bellsoft-liberica-vm-full-openjdk23.0.1+13-24.1.1+1-macos-amd64.zip"
+      },
+      "jdk@liberica-nik-std-java11": {
+        "11.0.10+9": "zip+https://download.bell-sw.com/vm/21.0.0.2/bellsoft-liberica-vm-openjdk11-21.0.0.2-macos-amd64.zip",
+        "11.0.11+9": "zip+https://download.bell-sw.com/vm/21.1.0/bellsoft-liberica-vm-openjdk11-21.1.0-macos-amd64.zip",
+        "11.0.12+7": "zip+https://download.bell-sw.com/vm/21.2.0/bellsoft-liberica-vm-openjdk11-21.2.0-macos-amd64.zip",
+        "11.0.13+8": "zip+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-openjdk11-21.3.0-macos-amd64.zip",
+        "11.0.14.1+1": "zip+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-openjdk11-21.3.1-macos-amd64.zip",
+        "11.0.15+10": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk11.0.15+10-21.3.2+1-macos-amd64.zip",
+        "11.0.15.1+2": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk11.0.15.1+2-21.3.2+2-macos-amd64.zip",
+        "11.0.16+8": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk11.0.16+8-21.3.3+1-macos-amd64.zip",
+        "11.0.16.1+1": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk11.0.16.1+1-21.3.3+2-macos-amd64.zip",
+        "11.0.17+7": "zip+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-openjdk11.0.17+7-21.3.3.1+1-macos-amd64.zip",
+        "11.0.18+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-openjdk11.0.18+10-22.3.1+1-macos-amd64.zip",
+        "11.0.19+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-openjdk11.0.19+7-22.3.2+1-macos-amd64.zip",
+        "11.0.20+8": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk11.0.20+8-22.3.3+1-macos-amd64.zip",
+        "11.0.20.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk11.0.20.1+1-22.3.3+2-macos-amd64.zip",
+        "11.0.21+10": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-openjdk11.0.21+9-22.3.4+1-macos-amd64.zip",
+        "11.0.22+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-openjdk11.0.22+12-22.3.5+1-macos-amd64.zip"
+      },
+      "jdk@liberica-nik-std-java17": {
+        "17.0.1+12": "zip+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-openjdk17-21.3.0-macos-amd64.zip",
+        "17.0.2+9": "zip+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-openjdk17-21.3.1-macos-amd64.zip",
+        "17.0.3+7": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk17.0.3+7-21.3.2+1-macos-amd64.zip",
+        "17.0.3.1+2": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk17.0.3.1+2-21.3.2+2-macos-amd64.zip",
+        "17.0.4+8": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk17.0.4+8-21.3.3+1-macos-amd64.zip",
+        "17.0.4.1+1": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk17.0.4.1+1-21.3.3+2-macos-amd64.zip",
+        "17.0.5+8": "zip+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-openjdk17.0.5+8-21.3.3.1+1-macos-amd64.zip",
+        "17.0.6+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-openjdk17.0.6+10-22.3.1+1-macos-amd64.zip",
+        "17.0.7+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-openjdk17.0.7+7-22.3.2+1-macos-amd64.zip",
+        "17.0.8+7": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk17.0.8+7-22.3.3+1-macos-amd64.zip",
+        "17.0.8.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk17.0.8.1+1-22.3.3+2-macos-amd64.zip",
+        "17.0.9+11": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-openjdk17.0.9+11-22.3.4+1-macos-amd64.zip",
+        "17.0.10+13": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-openjdk17.0.10+13-22.3.5+1-macos-amd64.zip",
+        "17.0.11+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-openjdk17.0.11+10-23.0.4+1-macos-amd64.zip",
+        "17.0.12+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-openjdk17.0.12+10-23.0.5+1-macos-amd64.zip",
+        "17.0.13+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-openjdk17.0.13+12-23.0.6+1-macos-amd64.zip"
+      },
+      "jdk@liberica-nik-std-java20": {
+        "20.0.1+10": "zip+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-openjdk20.0.1+10-23.0.0+1-macos-amd64.zip",
+        "20.0.2+10": "zip+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-openjdk20.0.2+10-23.0.1+1-macos-amd64.zip"
+      },
+      "jdk@liberica-nik-std-java21": {
+        "21+37.0.0": "zip+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-openjdk21+37-23.1.0+1-macos-amd64.zip",
+        "21.0.1+12": "zip+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-openjdk21.0.1+12-23.1.1+1-macos-amd64.zip",
+        "21.0.2+14": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-openjdk21.0.2+14-23.1.2+1-macos-amd64.zip",
+        "21.0.3+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-openjdk21.0.3+10-23.1.3+2-macos-amd64.zip",
+        "21.0.4+9": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-openjdk21.0.4+9-23.1.4+3-macos-amd64.zip",
+        "21.0.5+11": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-openjdk21.0.5+11-23.1.5+1-macos-amd64.zip"
+      },
+      "jdk@liberica-nik-std-java22": {
+        "22+37.0.0": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.0+1-22+37/bellsoft-liberica-vm-openjdk22+37-24.0.0+1-macos-amd64.zip",
+        "22.0.1+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.1+1-22.0.1+10/bellsoft-liberica-vm-openjdk22.0.1+10-24.0.1+1-macos-amd64.zip",
+        "22.0.2+11": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.2+1-22.0.2+11/bellsoft-liberica-vm-openjdk22.0.2+11-24.0.2+1-macos-amd64.zip"
+      },
+      "jdk@liberica-nik-std-java23": {
+        "23+38": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.0+1-23+38/bellsoft-liberica-vm-openjdk23+38-24.1.0+1-macos-amd64.zip",
+        "23.0.1+13": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.1+1-23.0.1+13/bellsoft-liberica-vm-openjdk23.0.1+13-24.1.1+1-macos-amd64.zip"
+      },
       "jdk@temurin": {
         "1.8.0-302": "tgz+https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08/OpenJDK8U-jdk_x64_mac_hotspot_8u302b08.tar.gz",
         "1.8.0-312": "tgz+https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jdk_x64_mac_hotspot_8u312b07.tar.gz",
@@ -4013,6 +4169,135 @@
         "22.0.2": "zip+https://github.com/bell-sw/Liberica/releases/download/22.0.2+11/bellsoft-jdk22.0.2+11-macos-aarch64-lite.zip",
         "23.0.0": "zip+https://github.com/bell-sw/Liberica/releases/download/23+38/bellsoft-jdk23+38-macos-aarch64-lite.zip",
         "23.0.1": "zip+https://github.com/bell-sw/Liberica/releases/download/23.0.1+13/bellsoft-jdk23.0.1+13-macos-aarch64-lite.zip"
+      },
+      "jdk@liberica-nik-core-java11": {
+        "11.0.16+8": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-core-openjdk11.0.16+8-22.2.0+2-macos-aarch64.zip",
+        "11.0.16.1+1": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-core-openjdk11.0.16.1+1-22.2.0+3-macos-aarch64.zip",
+        "11.0.17+7": "zip+https://download.bell-sw.com/vm/22.3.0/bellsoft-liberica-vm-core-openjdk11.0.17+7-22.3.0+2-macos-aarch64.zip",
+        "11.0.18+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-core-openjdk11.0.18+10-22.3.1+1-macos-aarch64.zip",
+        "11.0.19+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-core-openjdk11.0.19+7-22.3.2+1-macos-aarch64.zip",
+        "11.0.20+8": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk11.0.20+8-22.3.3+1-macos-aarch64.zip",
+        "11.0.20.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk11.0.20.1+1-22.3.3+2-macos-aarch64.zip",
+        "11.0.21+10": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-core-openjdk11.0.21+9-22.3.4+1-macos-aarch64.zip",
+        "11.0.22+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-core-openjdk11.0.22+12-22.3.5+1-macos-aarch64.zip"
+      },
+      "jdk@liberica-nik-core-java17": {
+        "17.0.4+8": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-core-openjdk17.0.4+8-22.2.0+2-macos-aarch64.zip",
+        "17.0.4.1+1": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-core-openjdk17.0.4.1+1-22.2.0+3-macos-aarch64.zip",
+        "17.0.5+8": "zip+https://download.bell-sw.com/vm/22.3.0/bellsoft-liberica-vm-core-openjdk17.0.5+8-22.3.0+2-macos-aarch64.zip",
+        "17.0.6+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-core-openjdk17.0.6+10-22.3.1+1-macos-aarch64.zip",
+        "17.0.7+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-core-openjdk17.0.7+7-22.3.2+1-macos-aarch64.zip",
+        "17.0.8+7": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk17.0.8+7-22.3.3+1-macos-aarch64.zip",
+        "17.0.8.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk17.0.8.1+1-22.3.3+2-macos-aarch64.zip",
+        "17.0.9+11": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-core-openjdk17.0.9+11-22.3.4+1-macos-aarch64.zip",
+        "17.0.10+13": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-core-openjdk17.0.10+13-22.3.5+1-macos-aarch64.zip",
+        "17.0.11+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-core-openjdk17.0.11+10-23.0.4+1-macos-aarch64.zip",
+        "17.0.12+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-core-openjdk17.0.12+10-23.0.5+1-macos-aarch64.zip",
+        "17.0.13+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-core-openjdk17.0.13+12-23.0.6+1-macos-aarch64.zip"
+      },
+      "jdk@liberica-nik-core-java20": {
+        "20.0.1+10": "zip+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-core-openjdk20.0.1+10-23.0.0+1-macos-aarch64.zip",
+        "20.0.2+10": "zip+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-core-openjdk20.0.2+10-23.0.1+1-macos-aarch64.zip"
+      },
+      "jdk@liberica-nik-core-java21": {
+        "21+37.0.0": "zip+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-core-openjdk21+37-23.1.0+1-macos-aarch64.zip",
+        "21.0.1+12": "zip+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-core-openjdk21.0.1+12-23.1.1+1-macos-aarch64.zip",
+        "21.0.2+14": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-core-openjdk21.0.2+14-23.1.2+1-macos-aarch64.zip",
+        "21.0.3+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-core-openjdk21.0.3+10-23.1.3+2-macos-aarch64.zip",
+        "21.0.4+9": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-core-openjdk21.0.4+9-23.1.4+3-macos-aarch64.zip",
+        "21.0.5+11": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-core-openjdk21.0.5+11-23.1.5+1-macos-aarch64.zip"
+      },
+      "jdk@liberica-nik-full-java11": {
+        "11.0.16+8": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-full-openjdk11.0.16+8-22.2.0+2-macos-aarch64.zip",
+        "11.0.16.1+1": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-full-openjdk11.0.16.1+1-22.2.0+3-macos-aarch64.zip",
+        "11.0.17+7": "zip+https://download.bell-sw.com/vm/22.3.0/bellsoft-liberica-vm-full-openjdk11.0.17+7-22.3.0+2-macos-aarch64.zip",
+        "11.0.18+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-full-openjdk11.0.18+10-22.3.1+1-macos-aarch64.zip",
+        "11.0.19+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-full-openjdk11.0.19+7-22.3.2+1-macos-aarch64.zip",
+        "11.0.20+8": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk11.0.20+8-22.3.3+1-macos-aarch64.zip",
+        "11.0.20.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk11.0.20.1+1-22.3.3+2-macos-aarch64.zip",
+        "11.0.21+10": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-full-openjdk11.0.21+9-22.3.4+1-macos-aarch64.zip",
+        "11.0.22+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-full-openjdk11.0.22+12-22.3.5+1-macos-aarch64.zip"
+      },
+      "jdk@liberica-nik-full-java17": {
+        "17.0.4+8": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-full-openjdk17.0.4+8-22.2.0+2-macos-aarch64.zip",
+        "17.0.4.1+1": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-full-openjdk17.0.4.1+1-22.2.0+3-macos-aarch64.zip",
+        "17.0.5+8": "zip+https://download.bell-sw.com/vm/22.3.0/bellsoft-liberica-vm-full-openjdk17.0.5+8-22.3.0+2-macos-aarch64.zip",
+        "17.0.6+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-full-openjdk17.0.6+10-22.3.1+1-macos-aarch64.zip",
+        "17.0.7+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-full-openjdk17.0.7+7-22.3.2+1-macos-aarch64.zip",
+        "17.0.8+7": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk17.0.8+7-22.3.3+1-macos-aarch64.zip",
+        "17.0.8.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk17.0.8.1+1-22.3.3+2-macos-aarch64.zip",
+        "17.0.9+11": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-full-openjdk17.0.9+11-22.3.4+1-macos-aarch64.zip",
+        "17.0.10+13": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-full-openjdk17.0.10+13-22.3.5+1-macos-aarch64.zip",
+        "17.0.11+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-full-openjdk17.0.11+10-23.0.4+1-macos-aarch64.zip",
+        "17.0.12+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-full-openjdk17.0.12+10-23.0.5+1-macos-aarch64.zip",
+        "17.0.13+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-full-openjdk17.0.13+12-23.0.6+1-macos-aarch64.zip"
+      },
+      "jdk@liberica-nik-full-java20": {
+        "20.0.1+10": "zip+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-full-openjdk20.0.1+10-23.0.0+1-macos-aarch64.zip",
+        "20.0.2+10": "zip+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-full-openjdk20.0.2+10-23.0.1+1-macos-aarch64.zip"
+      },
+      "jdk@liberica-nik-full-java21": {
+        "21+37.0.0": "zip+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-full-openjdk21+37-23.1.0+1-macos-aarch64.zip",
+        "21.0.1+12": "zip+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-full-openjdk21.0.1+12-23.1.1+1-macos-aarch64.zip",
+        "21.0.2+14": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-full-openjdk21.0.2+14-23.1.2+1-macos-aarch64.zip",
+        "21.0.3+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-full-openjdk21.0.3+10-23.1.3+2-macos-aarch64.zip",
+        "21.0.4+9": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-full-openjdk21.0.4+9-23.1.4+3-macos-aarch64.zip",
+        "21.0.5+11": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-full-openjdk21.0.5+11-23.1.5+1-macos-aarch64.zip"
+      },
+      "jdk@liberica-nik-full-java22": {
+        "22+37.0.0": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.0+1-22+37/bellsoft-liberica-vm-full-openjdk22+37-24.0.0+1-macos-aarch64.zip",
+        "22.0.1+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.1+1-22.0.1+10/bellsoft-liberica-vm-full-openjdk22.0.1+10-24.0.1+1-macos-aarch64.zip",
+        "22.0.2+11": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.2+1-22.0.2+11/bellsoft-liberica-vm-full-openjdk22.0.2+11-24.0.2+1-macos-aarch64.zip"
+      },
+      "jdk@liberica-nik-full-java23": {
+        "23+38": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.0+1-23+38/bellsoft-liberica-vm-full-openjdk23+38-24.1.0+1-macos-aarch64.zip",
+        "23.0.1+13": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.1+1-23.0.1+13/bellsoft-liberica-vm-full-openjdk23.0.1+13-24.1.1+1-macos-aarch64.zip"
+      },
+      "jdk@liberica-nik-std-java11": {
+        "11.0.16+8": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-openjdk11.0.16+8-22.2.0+2-macos-aarch64.zip",
+        "11.0.16.1+1": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-openjdk11.0.16.1+1-22.2.0+3-macos-aarch64.zip",
+        "11.0.17+7": "zip+https://download.bell-sw.com/vm/22.3.0/bellsoft-liberica-vm-openjdk11.0.17+7-22.3.0+2-macos-aarch64.zip",
+        "11.0.18+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-openjdk11.0.18+10-22.3.1+1-macos-aarch64.zip",
+        "11.0.19+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-openjdk11.0.19+7-22.3.2+1-macos-aarch64.zip",
+        "11.0.20+8": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk11.0.20+8-22.3.3+1-macos-aarch64.zip",
+        "11.0.20.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk11.0.20.1+1-22.3.3+2-macos-aarch64.zip",
+        "11.0.21+10": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-openjdk11.0.21+9-22.3.4+1-macos-aarch64.zip",
+        "11.0.22+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-openjdk11.0.22+12-22.3.5+1-macos-aarch64.zip"
+      },
+      "jdk@liberica-nik-std-java17": {
+        "17.0.4+8": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-openjdk17.0.4+8-22.2.0+2-macos-aarch64.zip",
+        "17.0.4.1+1": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-openjdk17.0.4.1+1-22.2.0+3-macos-aarch64.zip",
+        "17.0.5+8": "zip+https://download.bell-sw.com/vm/22.3.0/bellsoft-liberica-vm-openjdk17.0.5+8-22.3.0+2-macos-aarch64.zip",
+        "17.0.6+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-openjdk17.0.6+10-22.3.1+1-macos-aarch64.zip",
+        "17.0.7+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-openjdk17.0.7+7-22.3.2+1-macos-aarch64.zip",
+        "17.0.8+7": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk17.0.8+7-22.3.3+1-macos-aarch64.zip",
+        "17.0.8.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk17.0.8.1+1-22.3.3+2-macos-aarch64.zip",
+        "17.0.9+11": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-openjdk17.0.9+11-22.3.4+1-macos-aarch64.zip",
+        "17.0.10+13": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-openjdk17.0.10+13-22.3.5+1-macos-aarch64.zip",
+        "17.0.11+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-openjdk17.0.11+10-23.0.4+1-macos-aarch64.zip",
+        "17.0.12+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-openjdk17.0.12+10-23.0.5+1-macos-aarch64.zip",
+        "17.0.13+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-openjdk17.0.13+12-23.0.6+1-macos-aarch64.zip"
+      },
+      "jdk@liberica-nik-std-java20": {
+        "20.0.1+10": "zip+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-openjdk20.0.1+10-23.0.0+1-macos-aarch64.zip",
+        "20.0.2+10": "zip+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-openjdk20.0.2+10-23.0.1+1-macos-aarch64.zip"
+      },
+      "jdk@liberica-nik-std-java21": {
+        "21+37.0.0": "zip+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-openjdk21+37-23.1.0+1-macos-aarch64.zip",
+        "21.0.1+12": "zip+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-openjdk21.0.1+12-23.1.1+1-macos-aarch64.zip",
+        "21.0.2+14": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-openjdk21.0.2+14-23.1.2+1-macos-aarch64.zip",
+        "21.0.3+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-openjdk21.0.3+10-23.1.3+2-macos-aarch64.zip",
+        "21.0.4+9": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-openjdk21.0.4+9-23.1.4+3-macos-aarch64.zip",
+        "21.0.5+11": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-openjdk21.0.5+11-23.1.5+1-macos-aarch64.zip"
+      },
+      "jdk@liberica-nik-std-java22": {
+        "22+37.0.0": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.0+1-22+37/bellsoft-liberica-vm-openjdk22+37-24.0.0+1-macos-aarch64.zip",
+        "22.0.1+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.1+1-22.0.1+10/bellsoft-liberica-vm-openjdk22.0.1+10-24.0.1+1-macos-aarch64.zip",
+        "22.0.2+11": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.2+1-22.0.2+11/bellsoft-liberica-vm-openjdk22.0.2+11-24.0.2+1-macos-aarch64.zip"
+      },
+      "jdk@liberica-nik-std-java23": {
+        "23+38": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.0+1-23+38/bellsoft-liberica-vm-openjdk23+38-24.1.0+1-macos-aarch64.zip",
+        "23.0.1+13": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.1+1-23.0.1+13/bellsoft-liberica-vm-openjdk23.0.1+13-24.1.1+1-macos-aarch64.zip"
       },
       "jdk@temurin": {
         "1.11.0.15": "tgz+https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.15%2B10/OpenJDK11U-jdk_aarch64_mac_hotspot_11.0.15_10.tar.gz",
@@ -5709,6 +5994,164 @@
         "22.0.2": "tgz+https://github.com/bell-sw/Liberica/releases/download/22.0.2+11/bellsoft-jdk22.0.2+11-linux-amd64-lite.tar.gz",
         "23.0.0": "tgz+https://github.com/bell-sw/Liberica/releases/download/23+38/bellsoft-jdk23+38-linux-amd64-lite.tar.gz",
         "23.0.1": "tgz+https://github.com/bell-sw/Liberica/releases/download/23.0.1+13/bellsoft-jdk23.0.1+13-linux-amd64-lite.tar.gz"
+      },
+      "jdk@liberica-nik-core-java11": {
+        "11.0.11+9": "tgz+https://download.bell-sw.com/vm/21.1.0/bellsoft-liberica-vm-core-openjdk11-21.1.0-linux-amd64.tar.gz",
+        "11.0.12+7": "tgz+https://download.bell-sw.com/vm/21.2.0/bellsoft-liberica-vm-core-openjdk11-21.2.0-linux-amd64.tar.gz",
+        "11.0.13+8": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-core-openjdk11-21.3.0-linux-amd64.tar.gz",
+        "11.0.14.1+1": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-core-openjdk11-21.3.1-linux-amd64.tar.gz",
+        "11.0.15+10": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk11.0.15+10-21.3.2+1-linux-amd64.tar.gz",
+        "11.0.15.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk11.0.15.1+2-21.3.2+2-linux-amd64.tar.gz",
+        "11.0.16+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk11.0.16+8-21.3.3+1-linux-amd64.tar.gz",
+        "11.0.16.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk11.0.16.1+1-21.3.3+2-linux-amd64.tar.gz",
+        "11.0.17+7": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-core-openjdk11.0.17+7-21.3.3.1+1-linux-amd64.tar.gz",
+        "11.0.18+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-core-openjdk11.0.18+10-22.3.1+1-linux-amd64.tar.gz",
+        "11.0.19+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-core-openjdk11.0.19+7-22.3.2+1-linux-amd64.tar.gz",
+        "11.0.20+8": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk11.0.20+8-22.3.3+1-linux-amd64.tar.gz",
+        "11.0.20.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk11.0.20.1+1-22.3.3+2-linux-amd64.tar.gz",
+        "11.0.21+10": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-core-openjdk11.0.21+10-22.3.4+1-linux-amd64.tar.gz",
+        "11.0.22+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-core-openjdk11.0.22+12-22.3.5+1-linux-amd64.tar.gz"
+      },
+      "jdk@liberica-nik-core-java17": {
+        "17.0.1+12": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-core-openjdk17-21.3.0-linux-amd64.tar.gz",
+        "17.0.2+9": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-core-openjdk17-21.3.1-linux-amd64.tar.gz",
+        "17.0.3+7": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk17.0.3+7-21.3.2+1-linux-amd64.tar.gz",
+        "17.0.3.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk17.0.3.1+2-21.3.2+2-linux-amd64.tar.gz",
+        "17.0.4+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk17.0.4+8-21.3.3+1-linux-amd64.tar.gz",
+        "17.0.4.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk17.0.4.1+1-21.3.3+2-linux-amd64.tar.gz",
+        "17.0.5+8": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-core-openjdk17.0.5+8-21.3.3.1+1-linux-amd64.tar.gz",
+        "17.0.6+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-core-openjdk17.0.6+10-22.3.1+1-linux-amd64.tar.gz",
+        "17.0.7+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-core-openjdk17.0.7+7-22.3.2+1-linux-amd64.tar.gz",
+        "17.0.8+7": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk17.0.8+7-22.3.3+1-linux-amd64.tar.gz",
+        "17.0.8.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk17.0.8.1+1-22.3.3+2-linux-amd64.tar.gz",
+        "17.0.9+11": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-core-openjdk17.0.9+11-22.3.4+1-linux-amd64.tar.gz",
+        "17.0.10+13": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-core-openjdk17.0.10+13-22.3.5+1-linux-amd64.tar.gz",
+        "17.0.11+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-core-openjdk17.0.11+10-23.0.4+1-linux-amd64.tar.gz",
+        "17.0.12+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-core-openjdk17.0.12+10-23.0.5+1-linux-amd64.tar.gz",
+        "17.0.13+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-core-openjdk17.0.13+12-23.0.6+1-linux-amd64.tar.gz"
+      },
+      "jdk@liberica-nik-core-java20": {
+        "20.0.1+10": "tgz+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-core-openjdk20.0.1+10-23.0.0+1-linux-amd64.tar.gz",
+        "20.0.2+10": "tgz+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-core-openjdk20.0.2+10-23.0.1+1-linux-amd64.tar.gz"
+      },
+      "jdk@liberica-nik-core-java21": {
+        "21+37.0.0": "tgz+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-core-openjdk21+37-23.1.0+1-linux-amd64.tar.gz",
+        "21.0.1+12": "tgz+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-core-openjdk21.0.1+12-23.1.1+1-linux-amd64.tar.gz",
+        "21.0.2+14": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-core-openjdk21.0.2+14-23.1.2+1-linux-amd64.tar.gz",
+        "21.0.3+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-core-openjdk21.0.3+10-23.1.3+2-linux-amd64.tar.gz",
+        "21.0.4+9": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-core-openjdk21.0.4+9-23.1.4+3-linux-amd64.tar.gz",
+        "21.0.5+11": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-core-openjdk21.0.5+11-23.1.5+1-linux-amd64.tar.gz"
+      },
+      "jdk@liberica-nik-full-java11": {
+        "11.0.13+8": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-full-openjdk11-21.3.0-linux-amd64.tar.gz",
+        "11.0.14.1+1": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-full-openjdk11-21.3.1-linux-amd64.tar.gz",
+        "11.0.15+10": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-full-openjdk11.0.15+10-21.3.2+1-linux-amd64.tar.gz",
+        "11.0.15.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-full-openjdk11.0.15.1+2-21.3.2+2-linux-amd64.tar.gz",
+        "11.0.16+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-full-openjdk11.0.16+8-21.3.3+1-linux-amd64.tar.gz",
+        "11.0.16.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-full-openjdk11.0.16.1+1-21.3.3+2-linux-amd64.tar.gz",
+        "11.0.17+7": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-full-openjdk11.0.17+7-21.3.3.1+1-linux-amd64.tar.gz",
+        "11.0.18+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-full-openjdk11.0.18+10-22.3.1+1-linux-amd64.tar.gz",
+        "11.0.19+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-full-openjdk11.0.19+7-22.3.2+1-linux-amd64.tar.gz",
+        "11.0.20+8": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk11.0.20+8-22.3.3+1-linux-amd64.tar.gz",
+        "11.0.20.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk11.0.20.1+1-22.3.3+2-linux-amd64.tar.gz",
+        "11.0.21+10": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-full-openjdk11.0.21+10-22.3.4+1-linux-amd64.tar.gz",
+        "11.0.22+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-full-openjdk11.0.22+12-22.3.5+1-linux-amd64.tar.gz"
+      },
+      "jdk@liberica-nik-full-java17": {
+        "17.0.1+12": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-full-openjdk17-21.3.0-linux-amd64.tar.gz",
+        "17.0.2+9": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-full-openjdk17-21.3.1-linux-amd64.tar.gz",
+        "17.0.3+7": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-full-openjdk17.0.3+7-21.3.2+1-linux-amd64.tar.gz",
+        "17.0.3.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-full-openjdk17.0.3.1+2-21.3.2+2-linux-amd64.tar.gz",
+        "17.0.4+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-full-openjdk17.0.4+8-21.3.3+1-linux-amd64.tar.gz",
+        "17.0.4.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-full-openjdk17.0.4.1+1-21.3.3+2-linux-amd64.tar.gz",
+        "17.0.5+8": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-full-openjdk17.0.5+8-21.3.3.1+1-linux-amd64.tar.gz",
+        "17.0.6+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-full-openjdk17.0.6+10-22.3.1+1-linux-amd64.tar.gz",
+        "17.0.7+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-full-openjdk17.0.7+7-22.3.2+1-linux-amd64.tar.gz",
+        "17.0.8+7": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk17.0.8+7-22.3.3+1-linux-amd64.tar.gz",
+        "17.0.8.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk17.0.8.1+1-22.3.3+2-linux-amd64.tar.gz",
+        "17.0.9+11": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-full-openjdk17.0.9+11-22.3.4+1-linux-amd64.tar.gz",
+        "17.0.10+13": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-full-openjdk17.0.10+13-22.3.5+1-linux-amd64.tar.gz",
+        "17.0.11+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-full-openjdk17.0.11+10-23.0.4+1-linux-amd64.tar.gz",
+        "17.0.12+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-full-openjdk17.0.12+10-23.0.5+1-linux-amd64.tar.gz",
+        "17.0.13+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-full-openjdk17.0.13+12-23.0.6+1-linux-amd64.tar.gz"
+      },
+      "jdk@liberica-nik-full-java20": {
+        "20.0.1+10": "tgz+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-full-openjdk20.0.1+10-23.0.0+1-linux-amd64.tar.gz",
+        "20.0.2+10": "tgz+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-full-openjdk20.0.2+10-23.0.1+1-linux-amd64.tar.gz"
+      },
+      "jdk@liberica-nik-full-java21": {
+        "21+37.0.0": "tgz+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-full-openjdk21+37-23.1.0+1-linux-amd64.tar.gz",
+        "21.0.1+12": "tgz+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-full-openjdk21.0.1+12-23.1.1+1-linux-amd64.tar.gz",
+        "21.0.2+14": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-full-openjdk21.0.2+14-23.1.2+1-linux-amd64.tar.gz",
+        "21.0.3+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-full-openjdk21.0.3+10-23.1.3+2-linux-amd64.tar.gz",
+        "21.0.4+9": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-full-openjdk21.0.4+9-23.1.4+3-linux-amd64.tar.gz",
+        "21.0.5+11": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-full-openjdk21.0.5+11-23.1.5+1-linux-amd64.tar.gz"
+      },
+      "jdk@liberica-nik-full-java22": {
+        "22+37.0.0": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.0+1-22+37/bellsoft-liberica-vm-full-openjdk22+37-24.0.0+1-linux-amd64.tar.gz",
+        "22.0.1+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.1+1-22.0.1+10/bellsoft-liberica-vm-full-openjdk22.0.1+10-24.0.1+1-linux-amd64.tar.gz",
+        "22.0.2+11": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.2+1-22.0.2+11/bellsoft-liberica-vm-full-openjdk22.0.2+11-24.0.2+1-linux-amd64.tar.gz"
+      },
+      "jdk@liberica-nik-full-java23": {
+        "23+38": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.0+1-23+38/bellsoft-liberica-vm-full-openjdk23+38-24.1.0+1-linux-amd64.tar.gz",
+        "23.0.1+13": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.1+1-23.0.1+13/bellsoft-liberica-vm-full-openjdk23.0.1+13-24.1.1+1-linux-amd64.tar.gz"
+      },
+      "jdk@liberica-nik-std-java11": {
+        "11.0.10+9": "tgz+https://download.bell-sw.com/vm/21.0.0.2/bellsoft-liberica-vm-openjdk11-21.0.0.2-linux-amd64.tar.gz",
+        "11.0.11+9": "tgz+https://download.bell-sw.com/vm/21.1.0/bellsoft-liberica-vm-openjdk11-21.1.0-linux-amd64.tar.gz",
+        "11.0.12+7": "tgz+https://download.bell-sw.com/vm/21.2.0/bellsoft-liberica-vm-openjdk11-21.2.0-linux-amd64.tar.gz",
+        "11.0.13+8": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-openjdk11-21.3.0-linux-amd64.tar.gz",
+        "11.0.14.1+1": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-openjdk11-21.3.1-linux-amd64.tar.gz",
+        "11.0.15+10": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk11.0.15+10-21.3.2+1-linux-amd64.tar.gz",
+        "11.0.15.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk11.0.15.1+2-21.3.2+2-linux-amd64.tar.gz",
+        "11.0.16+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk11.0.16+8-21.3.3+1-linux-amd64.tar.gz",
+        "11.0.16.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk11.0.16.1+1-21.3.3+2-linux-amd64.tar.gz",
+        "11.0.17+7": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-openjdk11.0.17+7-21.3.3.1+1-linux-amd64.tar.gz",
+        "11.0.18+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-openjdk11.0.18+10-22.3.1+1-linux-amd64.tar.gz",
+        "11.0.19+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-openjdk11.0.19+7-22.3.2+1-linux-amd64.tar.gz",
+        "11.0.20+8": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk11.0.20+8-22.3.3+1-linux-amd64.tar.gz",
+        "11.0.20.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk11.0.20.1+1-22.3.3+2-linux-amd64.tar.gz",
+        "11.0.21+10": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-openjdk11.0.21+10-22.3.4+1-linux-amd64.tar.gz",
+        "11.0.22+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-openjdk11.0.22+12-22.3.5+1-linux-amd64.tar.gz"
+      },
+      "jdk@liberica-nik-std-java17": {
+        "17.0.1+12": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-openjdk17-21.3.0-linux-amd64.tar.gz",
+        "17.0.2+9": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-openjdk17-21.3.1-linux-amd64.tar.gz",
+        "17.0.3+7": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk17.0.3+7-21.3.2+1-linux-amd64.tar.gz",
+        "17.0.3.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk17.0.3.1+2-21.3.2+2-linux-amd64.tar.gz",
+        "17.0.4+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk17.0.4+8-21.3.3+1-linux-amd64.tar.gz",
+        "17.0.4.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk17.0.4.1+1-21.3.3+2-linux-amd64.tar.gz",
+        "17.0.5+8": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-openjdk17.0.5+8-21.3.3.1+1-linux-amd64.tar.gz",
+        "17.0.6+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-openjdk17.0.6+10-22.3.1+1-linux-amd64.tar.gz",
+        "17.0.7+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-openjdk17.0.7+7-22.3.2+1-linux-amd64.tar.gz",
+        "17.0.8+7": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk17.0.8+7-22.3.3+1-linux-amd64.tar.gz",
+        "17.0.8.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk17.0.8.1+1-22.3.3+2-linux-amd64.tar.gz",
+        "17.0.9+11": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-openjdk17.0.9+11-22.3.4+1-linux-amd64.tar.gz",
+        "17.0.10+13": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-openjdk17.0.10+13-22.3.5+1-linux-amd64.tar.gz",
+        "17.0.11+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-openjdk17.0.11+10-23.0.4+1-linux-amd64.tar.gz",
+        "17.0.12+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-openjdk17.0.12+10-23.0.5+1-linux-amd64.tar.gz",
+        "17.0.13+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-openjdk17.0.13+12-23.0.6+1-linux-amd64.tar.gz"
+      },
+      "jdk@liberica-nik-std-java20": {
+        "20.0.1+10": "tgz+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-openjdk20.0.1+10-23.0.0+1-linux-amd64.tar.gz",
+        "20.0.2+10": "tgz+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-openjdk20.0.2+10-23.0.1+1-linux-amd64.tar.gz"
+      },
+      "jdk@liberica-nik-std-java21": {
+        "21+37.0.0": "tgz+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-openjdk21+37-23.1.0+1-linux-amd64.tar.gz",
+        "21.0.1+12": "tgz+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-openjdk21.0.1+12-23.1.1+1-linux-amd64.tar.gz",
+        "21.0.2+14": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-openjdk21.0.2+14-23.1.2+1-linux-amd64.tar.gz",
+        "21.0.3+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-openjdk21.0.3+10-23.1.3+2-linux-amd64.tar.gz",
+        "21.0.4+9": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-openjdk21.0.4+9-23.1.4+3-linux-amd64.tar.gz",
+        "21.0.5+11": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-openjdk21.0.5+11-23.1.5+1-linux-amd64.tar.gz"
+      },
+      "jdk@liberica-nik-std-java22": {
+        "22+37.0.0": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.0+1-22+37/bellsoft-liberica-vm-openjdk22+37-24.0.0+1-linux-amd64.tar.gz",
+        "22.0.1+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.1+1-22.0.1+10/bellsoft-liberica-vm-openjdk22.0.1+10-24.0.1+1-linux-amd64.tar.gz",
+        "22.0.2+11": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.2+1-22.0.2+11/bellsoft-liberica-vm-openjdk22.0.2+11-24.0.2+1-linux-amd64.tar.gz"
+      },
+      "jdk@liberica-nik-std-java23": {
+        "23+38": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.0+1-23+38/bellsoft-liberica-vm-openjdk23+38-24.1.0+1-linux-amd64.tar.gz",
+        "23.0.1+13": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.1+1-23.0.1+13/bellsoft-liberica-vm-openjdk23.0.1+13-24.1.1+1-linux-amd64.tar.gz"
       },
       "jdk@temurin": {
         "1.8.0-302": "tgz+https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u302b08.tar.gz",
@@ -8476,6 +8919,110 @@
         "22.0.2": "tgz+https://github.com/bell-sw/Liberica/releases/download/22.0.2+11/bellsoft-jdk22.0.2+11-linux-aarch64-lite.tar.gz",
         "23.0.0": "tgz+https://github.com/bell-sw/Liberica/releases/download/23+38/bellsoft-jdk23+38-linux-aarch64-lite.tar.gz",
         "23.0.1": "tgz+https://github.com/bell-sw/Liberica/releases/download/23.0.1+13/bellsoft-jdk23.0.1+13-linux-aarch64-lite.tar.gz"
+      },
+      "jdk@liberica-nik-core-java11": {
+        "11.0.11+9": "tgz+https://download.bell-sw.com/vm/21.1.0/bellsoft-liberica-vm-core-openjdk11-21.1.0-linux-aarch64.tar.gz",
+        "11.0.12+7": "tgz+https://download.bell-sw.com/vm/21.2.0/bellsoft-liberica-vm-core-openjdk11-21.2.0-linux-aarch64.tar.gz",
+        "11.0.13+8": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-core-openjdk11-21.3.0-linux-aarch64.tar.gz",
+        "11.0.14.1+1": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-core-openjdk11-21.3.1-linux-aarch64.tar.gz",
+        "11.0.15+10": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk11.0.15+10-21.3.2+1-linux-aarch64.tar.gz",
+        "11.0.15.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk11.0.15.1+2-21.3.2+2-linux-aarch64.tar.gz",
+        "11.0.16+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk11.0.16+8-21.3.3+1-linux-aarch64.tar.gz",
+        "11.0.16.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk11.0.16.1+1-21.3.3+2-linux-aarch64.tar.gz",
+        "11.0.17+7": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-core-openjdk11.0.17+7-21.3.3.1+1-linux-aarch64.tar.gz",
+        "11.0.18+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-core-openjdk11.0.18+10-22.3.1+1-linux-aarch64.tar.gz",
+        "11.0.19+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-core-openjdk11.0.19+7-22.3.2+1-linux-aarch64.tar.gz",
+        "11.0.20+8": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk11.0.20+8-22.3.3+1-linux-aarch64.tar.gz",
+        "11.0.20.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk11.0.20.1+1-22.3.3+2-linux-aarch64.tar.gz",
+        "11.0.21+10": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-core-openjdk11.0.21+10-22.3.4+1-linux-aarch64.tar.gz",
+        "11.0.22+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-core-openjdk11.0.22+12-22.3.5+1-linux-aarch64.tar.gz"
+      },
+      "jdk@liberica-nik-core-java17": {
+        "17.0.1+12": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-core-openjdk17-21.3.0-linux-aarch64.tar.gz",
+        "17.0.2+9": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-core-openjdk17-21.3.1-linux-aarch64.tar.gz",
+        "17.0.3+7": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk17.0.3+7-21.3.2+1-linux-aarch64.tar.gz",
+        "17.0.3.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk17.0.3.1+2-21.3.2+2-linux-aarch64.tar.gz",
+        "17.0.4+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk17.0.4+8-21.3.3+1-linux-aarch64.tar.gz",
+        "17.0.4.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk17.0.4.1+1-21.3.3+2-linux-aarch64.tar.gz",
+        "17.0.5+8": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-core-openjdk17.0.5+8-21.3.3.1+1-linux-aarch64.tar.gz",
+        "17.0.6+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-core-openjdk17.0.6+10-22.3.1+1-linux-aarch64.tar.gz",
+        "17.0.7+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-core-openjdk17.0.7+7-22.3.2+1-linux-aarch64.tar.gz",
+        "17.0.8+7": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk17.0.8+7-22.3.3+1-linux-aarch64.tar.gz",
+        "17.0.8.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk17.0.8.1+1-22.3.3+2-linux-aarch64.tar.gz",
+        "17.0.9+11": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-core-openjdk17.0.9+11-22.3.4+1-linux-aarch64.tar.gz",
+        "17.0.10+13": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-core-openjdk17.0.10+13-22.3.5+1-linux-aarch64.tar.gz",
+        "17.0.11+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-core-openjdk17.0.11+10-23.0.4+1-linux-aarch64.tar.gz",
+        "17.0.12+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-core-openjdk17.0.12+10-23.0.5+1-linux-aarch64.tar.gz",
+        "17.0.13+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-core-openjdk17.0.13+12-23.0.6+1-linux-aarch64.tar.gz"
+      },
+      "jdk@liberica-nik-core-java20": {
+        "20.0.1+10": "tgz+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-core-openjdk20.0.1+10-23.0.0+1-linux-aarch64.tar.gz",
+        "20.0.2+10": "tgz+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-core-openjdk20.0.2+10-23.0.1+1-linux-aarch64.tar.gz"
+      },
+      "jdk@liberica-nik-core-java21": {
+        "21+37.0.0": "tgz+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-core-openjdk21+37-23.1.0+1-linux-aarch64.tar.gz",
+        "21.0.1+12": "tgz+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-core-openjdk21.0.1+12-23.1.1+1-linux-aarch64.tar.gz",
+        "21.0.2+14": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-core-openjdk21.0.2+14-23.1.2+1-linux-aarch64.tar.gz",
+        "21.0.3+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-core-openjdk21.0.3+10-23.1.3+2-linux-aarch64.tar.gz",
+        "21.0.4+9": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-core-openjdk21.0.4+9-23.1.4+3-linux-aarch64.tar.gz",
+        "21.0.5+11": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-core-openjdk21.0.5+11-23.1.5+1-linux-aarch64.tar.gz"
+      },
+      "jdk@liberica-nik-std-java11": {
+        "11.0.10+9": "tgz+https://download.bell-sw.com/vm/21.0.0.2/bellsoft-liberica-vm-openjdk11-21.0.0.2-linux-aarch64.tar.gz",
+        "11.0.11+9": "tgz+https://download.bell-sw.com/vm/21.1.0/bellsoft-liberica-vm-openjdk11-21.1.0-linux-aarch64.tar.gz",
+        "11.0.12+7": "tgz+https://download.bell-sw.com/vm/21.2.0/bellsoft-liberica-vm-openjdk11-21.2.0-linux-aarch64.tar.gz",
+        "11.0.13+8": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-openjdk11-21.3.0-linux-aarch64.tar.gz",
+        "11.0.14.1+1": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-openjdk11-21.3.1-linux-aarch64.tar.gz",
+        "11.0.15+10": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk11.0.15+10-21.3.2+1-linux-aarch64.tar.gz",
+        "11.0.15.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk11.0.15.1+2-21.3.2+2-linux-aarch64.tar.gz",
+        "11.0.16+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk11.0.16+8-21.3.3+1-linux-aarch64.tar.gz",
+        "11.0.16.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk11.0.16.1+1-21.3.3+2-linux-aarch64.tar.gz",
+        "11.0.17+7": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-openjdk11.0.17+7-21.3.3.1+1-linux-aarch64.tar.gz",
+        "11.0.18+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-openjdk11.0.18+10-22.3.1+1-linux-aarch64.tar.gz",
+        "11.0.19+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-openjdk11.0.19+7-22.3.2+1-linux-aarch64.tar.gz",
+        "11.0.20+8": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk11.0.20+8-22.3.3+1-linux-aarch64.tar.gz",
+        "11.0.20.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk11.0.20.1+1-22.3.3+2-linux-aarch64.tar.gz",
+        "11.0.21+10": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-openjdk11.0.21+10-22.3.4+1-linux-aarch64.tar.gz",
+        "11.0.22+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-openjdk11.0.22+12-22.3.5+1-linux-aarch64.tar.gz"
+      },
+      "jdk@liberica-nik-std-java17": {
+        "17.0.1+12": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-openjdk17-21.3.0-linux-aarch64.tar.gz",
+        "17.0.2+9": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-openjdk17-21.3.1-linux-aarch64.tar.gz",
+        "17.0.3+7": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk17.0.3+7-21.3.2+1-linux-aarch64.tar.gz",
+        "17.0.3.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk17.0.3.1+2-21.3.2+2-linux-aarch64.tar.gz",
+        "17.0.4+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk17.0.4+8-21.3.3+1-linux-aarch64.tar.gz",
+        "17.0.4.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk17.0.4.1+1-21.3.3+2-linux-aarch64.tar.gz",
+        "17.0.5+8": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-openjdk17.0.5+8-21.3.3.1+1-linux-aarch64.tar.gz",
+        "17.0.6+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-openjdk17.0.6+10-22.3.1+1-linux-aarch64.tar.gz",
+        "17.0.7+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-openjdk17.0.7+7-22.3.2+1-linux-aarch64.tar.gz",
+        "17.0.8+7": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk17.0.8+7-22.3.3+1-linux-aarch64.tar.gz",
+        "17.0.8.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk17.0.8.1+1-22.3.3+2-linux-aarch64.tar.gz",
+        "17.0.9+11": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-openjdk17.0.9+11-22.3.4+1-linux-aarch64.tar.gz",
+        "17.0.10+13": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-openjdk17.0.10+13-22.3.5+1-linux-aarch64.tar.gz",
+        "17.0.11+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-openjdk17.0.11+10-23.0.4+1-linux-aarch64.tar.gz",
+        "17.0.12+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-openjdk17.0.12+10-23.0.5+1-linux-aarch64.tar.gz",
+        "17.0.13+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-openjdk17.0.13+12-23.0.6+1-linux-aarch64.tar.gz"
+      },
+      "jdk@liberica-nik-std-java20": {
+        "20.0.1+10": "tgz+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-openjdk20.0.1+10-23.0.0+1-linux-aarch64.tar.gz",
+        "20.0.2+10": "tgz+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-openjdk20.0.2+10-23.0.1+1-linux-aarch64.tar.gz"
+      },
+      "jdk@liberica-nik-std-java21": {
+        "21+37.0.0": "tgz+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-openjdk21+37-23.1.0+1-linux-aarch64.tar.gz",
+        "21.0.1+12": "tgz+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-openjdk21.0.1+12-23.1.1+1-linux-aarch64.tar.gz",
+        "21.0.2+14": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-openjdk21.0.2+14-23.1.2+1-linux-aarch64.tar.gz",
+        "21.0.3+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-openjdk21.0.3+10-23.1.3+2-linux-aarch64.tar.gz",
+        "21.0.4+9": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-openjdk21.0.4+9-23.1.4+3-linux-aarch64.tar.gz",
+        "21.0.5+11": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-openjdk21.0.5+11-23.1.5+1-linux-aarch64.tar.gz"
+      },
+      "jdk@liberica-nik-std-java22": {
+        "22+37.0.0": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.0+1-22+37/bellsoft-liberica-vm-openjdk22+37-24.0.0+1-linux-aarch64.tar.gz",
+        "22.0.1+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.1+1-22.0.1+10/bellsoft-liberica-vm-openjdk22.0.1+10-24.0.1+1-linux-aarch64.tar.gz",
+        "22.0.2+11": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.2+1-22.0.2+11/bellsoft-liberica-vm-openjdk22.0.2+11-24.0.2+1-linux-aarch64.tar.gz"
+      },
+      "jdk@liberica-nik-std-java23": {
+        "23+38": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.0+1-23+38/bellsoft-liberica-vm-openjdk23+38-24.1.0+1-linux-aarch64.tar.gz",
+        "23.0.1+13": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.1+1-23.0.1+13/bellsoft-liberica-vm-openjdk23.0.1+13-24.1.1+1-linux-aarch64.tar.gz"
       },
       "jdk@temurin": {
         "1.8.0-302": "tgz+https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_8u302b08.tar.gz",
@@ -11619,6 +12166,110 @@
         "23.0.0": "tgz+https://github.com/bell-sw/Liberica/releases/download/23+38/bellsoft-jdk23+38-linux-x64-musl-lite.tar.gz",
         "23.0.1": "tgz+https://github.com/bell-sw/Liberica/releases/download/23.0.1+13/bellsoft-jdk23.0.1+13-linux-x64-musl-lite.tar.gz"
       },
+      "jdk@liberica-nik-core-java11": {
+        "11.0.11+9": "tgz+https://download.bell-sw.com/vm/21.1.0/bellsoft-liberica-vm-core-openjdk11-21.1.0-linux-x64-musl.tar.gz",
+        "11.0.12+7": "tgz+https://download.bell-sw.com/vm/21.2.0/bellsoft-liberica-vm-core-openjdk11-21.2.0-linux-x64-musl.tar.gz",
+        "11.0.13+8": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-core-openjdk11-21.3.0-linux-x64-musl.tar.gz",
+        "11.0.14.1+1": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-core-openjdk11-21.3.1-linux-x64-musl.tar.gz",
+        "11.0.15+10": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk11.0.15+10-21.3.2+1-linux-x64-musl.tar.gz",
+        "11.0.15.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk11.0.15.1+2-21.3.2+2-linux-x64-musl.tar.gz",
+        "11.0.16+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk11.0.16+8-21.3.3+1-linux-x64-musl.tar.gz",
+        "11.0.16.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk11.0.16.1+1-21.3.3+2-linux-x64-musl.tar.gz",
+        "11.0.17+7": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-core-openjdk11.0.17+7-21.3.3.1+1-linux-x64-musl.tar.gz",
+        "11.0.18+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-core-openjdk11.0.18+10-22.3.1+1-linux-x64-musl.tar.gz",
+        "11.0.19+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-core-openjdk11.0.19+7-22.3.2+1-linux-x64-musl.tar.gz",
+        "11.0.20+8": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk11.0.20+8-22.3.3+1-linux-x64-musl.tar.gz",
+        "11.0.20.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk11.0.20.1+1-22.3.3+2-linux-x64-musl.tar.gz",
+        "11.0.21+10": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-core-openjdk11.0.21+10-22.3.4+1-linux-x64-musl.tar.gz",
+        "11.0.22+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-core-openjdk11.0.22+12-22.3.5+1-linux-x64-musl.tar.gz"
+      },
+      "jdk@liberica-nik-core-java17": {
+        "17.0.1+12": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-core-openjdk17-21.3.0-linux-x64-musl.tar.gz",
+        "17.0.2+9": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-core-openjdk17-21.3.1-linux-x64-musl.tar.gz",
+        "17.0.3+7": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk17.0.3+7-21.3.2+1-linux-x64-musl.tar.gz",
+        "17.0.3.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk17.0.3.1+2-21.3.2+2-linux-x64-musl.tar.gz",
+        "17.0.4+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk17.0.4+8-21.3.3+1-linux-x64-musl.tar.gz",
+        "17.0.4.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk17.0.4.1+1-21.3.3+2-linux-x64-musl.tar.gz",
+        "17.0.5+8": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-core-openjdk17.0.5+8-21.3.3.1+1-linux-x64-musl.tar.gz",
+        "17.0.6+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-core-openjdk17.0.6+10-22.3.1+1-linux-x64-musl.tar.gz",
+        "17.0.7+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-core-openjdk17.0.7+7-22.3.2+1-linux-x64-musl.tar.gz",
+        "17.0.8+7": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk17.0.8+7-22.3.3+1-linux-x64-musl.tar.gz",
+        "17.0.8.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk17.0.8.1+1-22.3.3+2-linux-x64-musl.tar.gz",
+        "17.0.9+11": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-core-openjdk17.0.9+11-22.3.4+1-linux-x64-musl.tar.gz",
+        "17.0.10+13": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-core-openjdk17.0.10+13-22.3.5+1-linux-x64-musl.tar.gz",
+        "17.0.11+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-core-openjdk17.0.11+10-23.0.4+1-linux-x64-musl.tar.gz",
+        "17.0.12+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-core-openjdk17.0.12+10-23.0.5+1-linux-x64-musl.tar.gz",
+        "17.0.13+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-core-openjdk17.0.13+12-23.0.6+1-linux-x64-musl.tar.gz"
+      },
+      "jdk@liberica-nik-core-java20": {
+        "20.0.1+10": "tgz+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-core-openjdk20.0.1+10-23.0.0+1-linux-x64-musl.tar.gz",
+        "20.0.2+10": "tgz+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-core-openjdk20.0.2+10-23.0.1+1-linux-x64-musl.tar.gz"
+      },
+      "jdk@liberica-nik-core-java21": {
+        "21+37.0.0": "tgz+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-core-openjdk21+37-23.1.0+1-linux-x64-musl.tar.gz",
+        "21.0.1+12": "tgz+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-core-openjdk21.0.1+12-23.1.1+1-linux-x64-musl.tar.gz",
+        "21.0.2+14": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-core-openjdk21.0.2+14-23.1.2+1-linux-x64-musl.tar.gz",
+        "21.0.3+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-core-openjdk21.0.3+10-23.1.3+2-linux-x64-musl.tar.gz",
+        "21.0.4+9": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-core-openjdk21.0.4+9-23.1.4+3-linux-x64-musl.tar.gz",
+        "21.0.5+11": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-core-openjdk21.0.5+11-23.1.5+1-linux-x64-musl.tar.gz"
+      },
+      "jdk@liberica-nik-std-java11": {
+        "11.0.10+9": "tgz+https://download.bell-sw.com/vm/21.0.0.2/bellsoft-liberica-vm-openjdk11-21.0.0.2-linux-x64-musl.tar.gz",
+        "11.0.11+9": "tgz+https://download.bell-sw.com/vm/21.1.0/bellsoft-liberica-vm-openjdk11-21.1.0-linux-x64-musl.tar.gz",
+        "11.0.12+7": "tgz+https://download.bell-sw.com/vm/21.2.0/bellsoft-liberica-vm-openjdk11-21.2.0-linux-x64-musl.tar.gz",
+        "11.0.13+8": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-openjdk11-21.3.0-linux-x64-musl.tar.gz",
+        "11.0.14.1+1": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-openjdk11-21.3.1-linux-x64-musl.tar.gz",
+        "11.0.15+10": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk11.0.15+10-21.3.2+1-linux-x64-musl.tar.gz",
+        "11.0.15.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk11.0.15.1+2-21.3.2+2-linux-x64-musl.tar.gz",
+        "11.0.16+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk11.0.16+8-21.3.3+1-linux-x64-musl.tar.gz",
+        "11.0.16.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk11.0.16.1+1-21.3.3+2-linux-x64-musl.tar.gz",
+        "11.0.17+7": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-openjdk11.0.17+7-21.3.3.1+1-linux-x64-musl.tar.gz",
+        "11.0.18+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-openjdk11.0.18+10-22.3.1+1-linux-x64-musl.tar.gz",
+        "11.0.19+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-openjdk11.0.19+7-22.3.2+1-linux-x64-musl.tar.gz",
+        "11.0.20+8": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk11.0.20+8-22.3.3+1-linux-x64-musl.tar.gz",
+        "11.0.20.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk11.0.20.1+1-22.3.3+2-linux-x64-musl.tar.gz",
+        "11.0.21+10": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-openjdk11.0.21+10-22.3.4+1-linux-x64-musl.tar.gz",
+        "11.0.22+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-openjdk11.0.22+12-22.3.5+1-linux-x64-musl.tar.gz"
+      },
+      "jdk@liberica-nik-std-java17": {
+        "17.0.1+12": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-openjdk17-21.3.0-linux-x64-musl.tar.gz",
+        "17.0.2+9": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-openjdk17-21.3.1-linux-x64-musl.tar.gz",
+        "17.0.3+7": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk17.0.3+7-21.3.2+1-linux-x64-musl.tar.gz",
+        "17.0.3.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk17.0.3.1+2-21.3.2+2-linux-x64-musl.tar.gz",
+        "17.0.4+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk17.0.4+8-21.3.3+1-linux-x64-musl.tar.gz",
+        "17.0.4.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk17.0.4.1+1-21.3.3+2-linux-x64-musl.tar.gz",
+        "17.0.5+8": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-openjdk17.0.5+8-21.3.3.1+1-linux-x64-musl.tar.gz",
+        "17.0.6+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-openjdk17.0.6+10-22.3.1+1-linux-x64-musl.tar.gz",
+        "17.0.7+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-openjdk17.0.7+7-22.3.2+1-linux-x64-musl.tar.gz",
+        "17.0.8+7": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk17.0.8+7-22.3.3+1-linux-x64-musl.tar.gz",
+        "17.0.8.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk17.0.8.1+1-22.3.3+2-linux-x64-musl.tar.gz",
+        "17.0.9+11": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-openjdk17.0.9+11-22.3.4+1-linux-x64-musl.tar.gz",
+        "17.0.10+13": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-openjdk17.0.10+13-22.3.5+1-linux-x64-musl.tar.gz",
+        "17.0.11+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-openjdk17.0.11+10-23.0.4+1-linux-x64-musl.tar.gz",
+        "17.0.12+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-openjdk17.0.12+10-23.0.5+1-linux-x64-musl.tar.gz",
+        "17.0.13+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-openjdk17.0.13+12-23.0.6+1-linux-x64-musl.tar.gz"
+      },
+      "jdk@liberica-nik-std-java20": {
+        "20.0.1+10": "tgz+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-openjdk20.0.1+10-23.0.0+1-linux-x64-musl.tar.gz",
+        "20.0.2+10": "tgz+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-openjdk20.0.2+10-23.0.1+1-linux-x64-musl.tar.gz"
+      },
+      "jdk@liberica-nik-std-java21": {
+        "21+37.0.0": "tgz+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-openjdk21+37-23.1.0+1-linux-x64-musl.tar.gz",
+        "21.0.1+12": "tgz+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-openjdk21.0.1+12-23.1.1+1-linux-x64-musl.tar.gz",
+        "21.0.2+14": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-openjdk21.0.2+14-23.1.2+1-linux-x64-musl.tar.gz",
+        "21.0.3+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-openjdk21.0.3+10-23.1.3+2-linux-x64-musl.tar.gz",
+        "21.0.4+9": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-openjdk21.0.4+9-23.1.4+3-linux-x64-musl.tar.gz",
+        "21.0.5+11": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-openjdk21.0.5+11-23.1.5+1-linux-x64-musl.tar.gz"
+      },
+      "jdk@liberica-nik-std-java22": {
+        "22+37.0.0": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.0+1-22+37/bellsoft-liberica-vm-openjdk22+37-24.0.0+1-linux-x64-musl.tar.gz",
+        "22.0.1+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.1+1-22.0.1+10/bellsoft-liberica-vm-openjdk22.0.1+10-24.0.1+1-linux-x64-musl.tar.gz",
+        "22.0.2+11": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.2+1-22.0.2+11/bellsoft-liberica-vm-openjdk22.0.2+11-24.0.2+1-linux-x64-musl.tar.gz"
+      },
+      "jdk@liberica-nik-std-java23": {
+        "23+38": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.0+1-23+38/bellsoft-liberica-vm-openjdk23+38-24.1.0+1-linux-x64-musl.tar.gz",
+        "23.0.1+13": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.1+1-23.0.1+13/bellsoft-liberica-vm-openjdk23.0.1+13-24.1.1+1-linux-x64-musl.tar.gz"
+      },
       "jdk@zulu": {
         "8.0.192": "tgz+https://cdn.azul.com/zulu/bin/zulu8.33.0.1-jdk8.0.192-linux_musl_x64.tar.gz",
         "8.0.201": "tgz+https://cdn.azul.com/zulu/bin/zulu8.34.0.1-ca-jdk8.0.201-linux_musl_x64.tar.gz",
@@ -12117,6 +12768,110 @@
         "22.0.2": "tgz+https://github.com/bell-sw/Liberica/releases/download/22.0.2+11/bellsoft-jdk22.0.2+11-linux-aarch64-musl-lite.tar.gz",
         "23.0.0": "tgz+https://github.com/bell-sw/Liberica/releases/download/23+38/bellsoft-jdk23+38-linux-aarch64-musl-lite.tar.gz",
         "23.0.1": "tgz+https://github.com/bell-sw/Liberica/releases/download/23.0.1+13/bellsoft-jdk23.0.1+13-linux-aarch64-musl-lite.tar.gz"
+      },
+      "jdk@liberica-nik-core-java11": {
+        "11.0.11+9": "tgz+https://download.bell-sw.com/vm/21.1.0/bellsoft-liberica-vm-core-openjdk11-21.1.0-linux-aarch64-musl.tar.gz",
+        "11.0.12+7": "tgz+https://download.bell-sw.com/vm/21.2.0/bellsoft-liberica-vm-core-openjdk11-21.2.0-linux-aarch64-musl.tar.gz",
+        "11.0.13+8": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-core-openjdk11-21.3.0-linux-aarch64-musl.tar.gz",
+        "11.0.14.1+1": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-core-openjdk11-21.3.1-linux-aarch64-musl.tar.gz",
+        "11.0.15+10": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk11.0.15+10-21.3.2+1-linux-aarch64-musl.tar.gz",
+        "11.0.15.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk11.0.15.1+2-21.3.2+2-linux-aarch64-musl.tar.gz",
+        "11.0.16+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk11.0.16+8-21.3.3+1-linux-aarch64-musl.tar.gz",
+        "11.0.16.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk11.0.16.1+1-21.3.3+2-linux-aarch64-musl.tar.gz",
+        "11.0.17+7": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-core-openjdk11.0.17+7-21.3.3.1+1-linux-aarch64-musl.tar.gz",
+        "11.0.18+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-core-openjdk11.0.18+10-22.3.1+1-linux-aarch64-musl.tar.gz",
+        "11.0.19+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-core-openjdk11.0.19+7-22.3.2+1-linux-aarch64-musl.tar.gz",
+        "11.0.20+8": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk11.0.20+8-22.3.3+1-linux-aarch64-musl.tar.gz",
+        "11.0.20.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk11.0.20.1+1-22.3.3+2-linux-aarch64-musl.tar.gz",
+        "11.0.21+10": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-core-openjdk11.0.21+10-22.3.4+1-linux-aarch64-musl.tar.gz",
+        "11.0.22+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-core-openjdk11.0.22+12-22.3.5+1-linux-aarch64-musl.tar.gz"
+      },
+      "jdk@liberica-nik-core-java17": {
+        "17.0.1+12": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-core-openjdk17-21.3.0-linux-aarch64-musl.tar.gz",
+        "17.0.2+9": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-core-openjdk17-21.3.1-linux-aarch64-musl.tar.gz",
+        "17.0.3+7": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk17.0.3+7-21.3.2+1-linux-aarch64-musl.tar.gz",
+        "17.0.3.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk17.0.3.1+2-21.3.2+2-linux-aarch64-musl.tar.gz",
+        "17.0.4+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk17.0.4+8-21.3.3+1-linux-aarch64-musl.tar.gz",
+        "17.0.4.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk17.0.4.1+1-21.3.3+2-linux-aarch64-musl.tar.gz",
+        "17.0.5+8": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-core-openjdk17.0.5+8-21.3.3.1+1-linux-aarch64-musl.tar.gz",
+        "17.0.6+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-core-openjdk17.0.6+10-22.3.1+1-linux-aarch64-musl.tar.gz",
+        "17.0.7+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-core-openjdk17.0.7+7-22.3.2+1-linux-aarch64-musl.tar.gz",
+        "17.0.8+7": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk17.0.8+7-22.3.3+1-linux-aarch64-musl.tar.gz",
+        "17.0.8.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk17.0.8.1+1-22.3.3+2-linux-aarch64-musl.tar.gz",
+        "17.0.9+11": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-core-openjdk17.0.9+11-22.3.4+1-linux-aarch64-musl.tar.gz",
+        "17.0.10+13": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-core-openjdk17.0.10+13-22.3.5+1-linux-aarch64-musl.tar.gz",
+        "17.0.11+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-core-openjdk17.0.11+10-23.0.4+1-linux-aarch64-musl.tar.gz",
+        "17.0.12+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-core-openjdk17.0.12+10-23.0.5+1-linux-aarch64-musl.tar.gz",
+        "17.0.13+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-core-openjdk17.0.13+12-23.0.6+1-linux-aarch64-musl.tar.gz"
+      },
+      "jdk@liberica-nik-core-java20": {
+        "20.0.1+10": "tgz+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-core-openjdk20.0.1+10-23.0.0+1-linux-aarch64-musl.tar.gz",
+        "20.0.2+10": "tgz+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-core-openjdk20.0.2+10-23.0.1+1-linux-aarch64-musl.tar.gz"
+      },
+      "jdk@liberica-nik-core-java21": {
+        "21+37.0.0": "tgz+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-core-openjdk21+37-23.1.0+1-linux-aarch64-musl.tar.gz",
+        "21.0.1+12": "tgz+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-core-openjdk21.0.1+12-23.1.1+1-linux-aarch64-musl.tar.gz",
+        "21.0.2+14": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-core-openjdk21.0.2+14-23.1.2+1-linux-aarch64-musl.tar.gz",
+        "21.0.3+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-core-openjdk21.0.3+10-23.1.3+2-linux-aarch64-musl.tar.gz",
+        "21.0.4+9": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-core-openjdk21.0.4+9-23.1.4+3-linux-aarch64-musl.tar.gz",
+        "21.0.5+11": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-core-openjdk21.0.5+11-23.1.5+1-linux-aarch64-musl.tar.gz"
+      },
+      "jdk@liberica-nik-std-java11": {
+        "11.0.10+9": "tgz+https://download.bell-sw.com/vm/21.0.0.2/bellsoft-liberica-vm-openjdk11-21.0.0.2-linux-aarch64-musl.tar.gz",
+        "11.0.11+9": "tgz+https://download.bell-sw.com/vm/21.1.0/bellsoft-liberica-vm-openjdk11-21.1.0-linux-aarch64-musl.tar.gz",
+        "11.0.12+7": "tgz+https://download.bell-sw.com/vm/21.2.0/bellsoft-liberica-vm-openjdk11-21.2.0-linux-aarch64-musl.tar.gz",
+        "11.0.13+8": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-openjdk11-21.3.0-linux-aarch64-musl.tar.gz",
+        "11.0.14.1+1": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-openjdk11-21.3.1-linux-aarch64-musl.tar.gz",
+        "11.0.15+10": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk11.0.15+10-21.3.2+1-linux-aarch64-musl.tar.gz",
+        "11.0.15.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk11.0.15.1+2-21.3.2+2-linux-aarch64-musl.tar.gz",
+        "11.0.16+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk11.0.16+8-21.3.3+1-linux-aarch64-musl.tar.gz",
+        "11.0.16.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk11.0.16.1+1-21.3.3+2-linux-aarch64-musl.tar.gz",
+        "11.0.17+7": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-openjdk11.0.17+7-21.3.3.1+1-linux-aarch64-musl.tar.gz",
+        "11.0.18+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-openjdk11.0.18+10-22.3.1+1-linux-aarch64-musl.tar.gz",
+        "11.0.19+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-openjdk11.0.19+7-22.3.2+1-linux-aarch64-musl.tar.gz",
+        "11.0.20+8": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk11.0.20+8-22.3.3+1-linux-aarch64-musl.tar.gz",
+        "11.0.20.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk11.0.20.1+1-22.3.3+2-linux-aarch64-musl.tar.gz",
+        "11.0.21+10": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-openjdk11.0.21+10-22.3.4+1-linux-aarch64-musl.tar.gz",
+        "11.0.22+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-openjdk11.0.22+12-22.3.5+1-linux-aarch64-musl.tar.gz"
+      },
+      "jdk@liberica-nik-std-java17": {
+        "17.0.1+12": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-openjdk17-21.3.0-linux-aarch64-musl.tar.gz",
+        "17.0.2+9": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-openjdk17-21.3.1-linux-aarch64-musl.tar.gz",
+        "17.0.3+7": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk17.0.3+7-21.3.2+1-linux-aarch64-musl.tar.gz",
+        "17.0.3.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk17.0.3.1+2-21.3.2+2-linux-aarch64-musl.tar.gz",
+        "17.0.4+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk17.0.4+8-21.3.3+1-linux-aarch64-musl.tar.gz",
+        "17.0.4.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk17.0.4.1+1-21.3.3+2-linux-aarch64-musl.tar.gz",
+        "17.0.5+8": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-openjdk17.0.5+8-21.3.3.1+1-linux-aarch64-musl.tar.gz",
+        "17.0.6+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-openjdk17.0.6+10-22.3.1+1-linux-aarch64-musl.tar.gz",
+        "17.0.7+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-openjdk17.0.7+7-22.3.2+1-linux-aarch64-musl.tar.gz",
+        "17.0.8+7": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk17.0.8+7-22.3.3+1-linux-aarch64-musl.tar.gz",
+        "17.0.8.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk17.0.8.1+1-22.3.3+2-linux-aarch64-musl.tar.gz",
+        "17.0.9+11": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-openjdk17.0.9+11-22.3.4+1-linux-aarch64-musl.tar.gz",
+        "17.0.10+13": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-openjdk17.0.10+13-22.3.5+1-linux-aarch64-musl.tar.gz",
+        "17.0.11+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-openjdk17.0.11+10-23.0.4+1-linux-aarch64-musl.tar.gz",
+        "17.0.12+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-openjdk17.0.12+10-23.0.5+1-linux-aarch64-musl.tar.gz",
+        "17.0.13+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-openjdk17.0.13+12-23.0.6+1-linux-aarch64-musl.tar.gz"
+      },
+      "jdk@liberica-nik-std-java20": {
+        "20.0.1+10": "tgz+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-openjdk20.0.1+10-23.0.0+1-linux-aarch64-musl.tar.gz",
+        "20.0.2+10": "tgz+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-openjdk20.0.2+10-23.0.1+1-linux-aarch64-musl.tar.gz"
+      },
+      "jdk@liberica-nik-std-java21": {
+        "21+37.0.0": "tgz+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-openjdk21+37-23.1.0+1-linux-aarch64-musl.tar.gz",
+        "21.0.1+12": "tgz+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-openjdk21.0.1+12-23.1.1+1-linux-aarch64-musl.tar.gz",
+        "21.0.2+14": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-openjdk21.0.2+14-23.1.2+1-linux-aarch64-musl.tar.gz",
+        "21.0.3+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-openjdk21.0.3+10-23.1.3+2-linux-aarch64-musl.tar.gz",
+        "21.0.4+9": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-openjdk21.0.4+9-23.1.4+3-linux-aarch64-musl.tar.gz",
+        "21.0.5+11": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-openjdk21.0.5+11-23.1.5+1-linux-aarch64-musl.tar.gz"
+      },
+      "jdk@liberica-nik-std-java22": {
+        "22+37.0.0": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.0+1-22+37/bellsoft-liberica-vm-openjdk22+37-24.0.0+1-linux-aarch64-musl.tar.gz",
+        "22.0.1+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.1+1-22.0.1+10/bellsoft-liberica-vm-openjdk22.0.1+10-24.0.1+1-linux-aarch64-musl.tar.gz",
+        "22.0.2+11": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.2+1-22.0.2+11/bellsoft-liberica-vm-openjdk22.0.2+11-24.0.2+1-linux-aarch64-musl.tar.gz"
+      },
+      "jdk@liberica-nik-std-java23": {
+        "23+38": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.0+1-23+38/bellsoft-liberica-vm-openjdk23+38-24.1.0+1-linux-aarch64-musl.tar.gz",
+        "23.0.1+13": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.1+1-23.0.1+13/bellsoft-liberica-vm-openjdk23.0.1+13-24.1.1+1-linux-aarch64-musl.tar.gz"
       },
       "jdk@zulu": {
         "8.0.332": "tgz+https://cdn.azul.com/zulu/bin/zulu8.62.0.19-ca-jdk8.0.332-linux_musl_aarch64.tar.gz",
@@ -13711,6 +14466,163 @@
         "22.0.2": "zip+https://github.com/bell-sw/Liberica/releases/download/22.0.2+11/bellsoft-jdk22.0.2+11-windows-amd64-lite.zip",
         "23.0.0": "zip+https://github.com/bell-sw/Liberica/releases/download/23+38/bellsoft-jdk23+38-windows-amd64-lite.zip",
         "23.0.1": "zip+https://github.com/bell-sw/Liberica/releases/download/23.0.1+13/bellsoft-jdk23.0.1+13-windows-amd64-lite.zip"
+      },
+      "jdk@liberica-nik-core-java11": {
+        "11.0.11+9": "zip+https://download.bell-sw.com/vm/21.1.0/bellsoft-liberica-vm-core-openjdk11-21.1.0-windows-amd64.zip",
+        "11.0.12+7": "zip+https://download.bell-sw.com/vm/21.2.0/bellsoft-liberica-vm-core-openjdk11-21.2.0-windows-amd64.zip",
+        "11.0.13+8": "zip+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-core-openjdk11-21.3.0-windows-amd64.zip",
+        "11.0.14.1+1": "zip+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-core-openjdk11-21.3.1-windows-amd64.zip",
+        "11.0.15+10": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk11.0.15+10-21.3.2+1-windows-amd64.zip",
+        "11.0.15.1+2": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk11.0.15.1+2-21.3.2+2-windows-amd64.zip",
+        "11.0.16+8": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk11.0.16+8-21.3.3+1-windows-amd64.zip",
+        "11.0.16.1+1": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk11.0.16.1+1-21.3.3+2-windows-amd64.zip",
+        "11.0.17+7": "zip+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-core-openjdk11.0.17+7-21.3.3.1+1-windows-amd64.zip",
+        "11.0.18+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-core-openjdk11.0.18+10-22.3.1+1-windows-amd64.zip",
+        "11.0.19+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-core-openjdk11.0.19+7-22.3.2+1-windows-amd64.zip",
+        "11.0.20+8": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk11.0.20+8-22.3.3+1-windows-amd64.zip",
+        "11.0.20.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk11.0.20.1+1-22.3.3+2-windows-amd64.zip",
+        "11.0.21+10": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-core-openjdk11.0.21+10-22.3.4+1-windows-amd64.zip",
+        "11.0.22+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-core-openjdk11.0.22+12-22.3.5+1-windows-amd64.zip"
+      },
+      "jdk@liberica-nik-core-java17": {
+        "17.0.1+12": "zip+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-core-openjdk17-21.3.0-windows-amd64.zip",
+        "17.0.2+9": "zip+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-core-openjdk17-21.3.1-windows-amd64.zip",
+        "17.0.3+7": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk17.0.3+7-21.3.2+1-windows-amd64.zip",
+        "17.0.3.1+2": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk17.0.3.1+2-21.3.2+2-windows-amd64.zip",
+        "17.0.4+8": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk17.0.4+8-21.3.3+1-windows-amd64.zip",
+        "17.0.4.1+1": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk17.0.4.1+1-21.3.3+2-windows-amd64.zip",
+        "17.0.5+8": "zip+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-core-openjdk17.0.5+8-21.3.3.1+1-windows-amd64.zip",
+        "17.0.6+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-core-openjdk17.0.6+10-22.3.1+1-windows-amd64.zip",
+        "17.0.7+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-core-openjdk17.0.7+7-22.3.2+1-windows-amd64.zip",
+        "17.0.8+7": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk17.0.8+7-22.3.3+1-windows-amd64.zip",
+        "17.0.8.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk17.0.8.1+1-22.3.3+2-windows-amd64.zip",
+        "17.0.9+11": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-core-openjdk17.0.9+11-22.3.4+1-windows-amd64.zip",
+        "17.0.10+13": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-core-openjdk17.0.10+13-22.3.5+1-windows-amd64.zip",
+        "17.0.11+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-core-openjdk17.0.11+10-23.0.4+1-windows-amd64.zip",
+        "17.0.12+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-core-openjdk17.0.12+10-23.0.5+1-windows-amd64.zip",
+        "17.0.13+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-core-openjdk17.0.13+12-23.0.6+1-windows-amd64.zip"
+      },
+      "jdk@liberica-nik-core-java20": {
+        "20.0.1+10": "zip+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-core-openjdk20.0.1+10-23.0.0+1-windows-amd64.zip",
+        "20.0.2+10": "zip+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-core-openjdk20.0.2+10-23.0.1+1-windows-amd64.zip"
+      },
+      "jdk@liberica-nik-core-java21": {
+        "21+37.0.0": "zip+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-core-openjdk21+37-23.1.0+1-windows-amd64.zip",
+        "21.0.1+12": "zip+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-core-openjdk21.0.1+12-23.1.1+1-windows-amd64.zip",
+        "21.0.2+14": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-core-openjdk21.0.2+14-23.1.2+1-windows-amd64.zip",
+        "21.0.3+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-core-openjdk21.0.3+10-23.1.3+2-windows-amd64.zip",
+        "21.0.4+9": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-core-openjdk21.0.4+9-23.1.4+3-windows-amd64.zip",
+        "21.0.5+11": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-core-openjdk21.0.5+11-23.1.5+1-windows-amd64.zip"
+      },
+      "jdk@liberica-nik-full-java11": {
+        "11.0.13+8": "zip+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-full-openjdk11-21.3.0-windows-amd64.zip",
+        "11.0.14.1+1": "zip+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-full-openjdk11-21.3.1-windows-amd64.zip",
+        "11.0.15+10": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-full-openjdk11.0.15+10-21.3.2+1-windows-amd64.zip",
+        "11.0.15.1+2": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-full-openjdk11.0.15.1+2-21.3.2+2-windows-amd64.zip",
+        "11.0.16+8": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-full-openjdk11.0.16+8-21.3.3+1-windows-amd64.zip",
+        "11.0.16.1+1": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-full-openjdk11.0.16.1+1-21.3.3+2-windows-amd64.zip",
+        "11.0.17+7": "zip+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-full-openjdk11.0.17+7-21.3.3.1+1-windows-amd64.zip",
+        "11.0.18+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-full-openjdk11.0.18+10-22.3.1+1-windows-amd64.zip",
+        "11.0.19+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-full-openjdk11.0.19+7-22.3.2+1-windows-amd64.zip",
+        "11.0.20+8": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk11.0.20+8-22.3.3+1-windows-amd64.zip",
+        "11.0.20.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk11.0.20.1+1-22.3.3+2-windows-amd64.zip",
+        "11.0.21+10": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-full-openjdk11.0.21+10-22.3.4+1-windows-amd64.zip",
+        "11.0.22+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-full-openjdk11.0.22+12-22.3.5+1-windows-amd64.zip"
+      },
+      "jdk@liberica-nik-full-java17": {
+        "17.0.1+12": "zip+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-full-openjdk17-21.3.0-windows-amd64.zip",
+        "17.0.2+9": "zip+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-full-openjdk17-21.3.1-windows-amd64.zip",
+        "17.0.3+7": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-full-openjdk17.0.3+7-21.3.2+1-windows-amd64.zip",
+        "17.0.3.1+2": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-full-openjdk17.0.3.1+2-21.3.2+2-windows-amd64.zip",
+        "17.0.4+8": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-full-openjdk17.0.4+8-21.3.3+1-windows-amd64.zip",
+        "17.0.4.1+1": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-full-openjdk17.0.4.1+1-21.3.3+2-windows-amd64.zip",
+        "17.0.5+8": "zip+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-full-openjdk17.0.5+8-21.3.3.1+1-windows-amd64.zip",
+        "17.0.6+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-full-openjdk17.0.6+10-22.3.1+1-windows-amd64.zip",
+        "17.0.7+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-full-openjdk17.0.7+7-22.3.2+1-windows-amd64.zip",
+        "17.0.8+7": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk17.0.8+7-22.3.3+1-windows-amd64.zip",
+        "17.0.8.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk17.0.8.1+1-22.3.3+2-windows-amd64.zip",
+        "17.0.9+11": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-full-openjdk17.0.9+11-22.3.4+1-windows-amd64.zip",
+        "17.0.10+13": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-full-openjdk17.0.10+13-22.3.5+1-windows-amd64.zip",
+        "17.0.11+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-full-openjdk17.0.11+10-23.0.4+1-windows-amd64.zip",
+        "17.0.12+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-full-openjdk17.0.12+10-23.0.5+1-windows-amd64.zip",
+        "17.0.13+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-full-openjdk17.0.13+12-23.0.6+1-windows-amd64.zip"
+      },
+      "jdk@liberica-nik-full-java20": {
+        "20.0.1+10": "zip+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-full-openjdk20.0.1+10-23.0.0+1-windows-amd64.zip",
+        "20.0.2+10": "zip+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-full-openjdk20.0.2+10-23.0.1+1-windows-amd64.zip"
+      },
+      "jdk@liberica-nik-full-java21": {
+        "21+37.0.0": "zip+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-full-openjdk21+37-23.1.0+1-windows-amd64.zip",
+        "21.0.1+12": "zip+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-full-openjdk21.0.1+12-23.1.1+1-windows-amd64.zip",
+        "21.0.2+14": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-full-openjdk21.0.2+14-23.1.2+1-windows-amd64.zip",
+        "21.0.3+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-full-openjdk21.0.3+10-23.1.3+2-windows-amd64.zip",
+        "21.0.4+9": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-full-openjdk21.0.4+9-23.1.4+3-windows-amd64.zip",
+        "21.0.5+11": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-full-openjdk21.0.5+11-23.1.5+1-windows-amd64.zip"
+      },
+      "jdk@liberica-nik-full-java22": {
+        "22+37.0.0": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.0+1-22+37/bellsoft-liberica-vm-full-openjdk22+37-24.0.0+1-windows-amd64.zip",
+        "22.0.1+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.1+1-22.0.1+10/bellsoft-liberica-vm-full-openjdk22.0.1+10-24.0.1+1-windows-amd64.zip",
+        "22.0.2+11": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.2+1-22.0.2+11/bellsoft-liberica-vm-full-openjdk22.0.2+11-24.0.2+1-windows-amd64.zip"
+      },
+      "jdk@liberica-nik-full-java23": {
+        "23+38": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.0+1-23+38/bellsoft-liberica-vm-full-openjdk23+38-24.1.0+1-windows-amd64.zip",
+        "23.0.1+13": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.1+1-23.0.1+13/bellsoft-liberica-vm-full-openjdk23.0.1+13-24.1.1+1-windows-amd64.zip"
+      },
+      "jdk@liberica-nik-std-java11": {
+        "11.0.11+9": "zip+https://download.bell-sw.com/vm/21.1.0/bellsoft-liberica-vm-openjdk11-21.1.0-windows-amd64.zip",
+        "11.0.12+7": "zip+https://download.bell-sw.com/vm/21.2.0/bellsoft-liberica-vm-openjdk11-21.2.0-windows-amd64.zip",
+        "11.0.13+8": "zip+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-openjdk11-21.3.0-windows-amd64.zip",
+        "11.0.14.1+1": "zip+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-openjdk11-21.3.1-windows-amd64.zip",
+        "11.0.15+10": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk11.0.15+10-21.3.2+1-windows-amd64.zip",
+        "11.0.15.1+2": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk11.0.15.1+2-21.3.2+2-windows-amd64.zip",
+        "11.0.16+8": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk11.0.16+8-21.3.3+1-windows-amd64.zip",
+        "11.0.16.1+1": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk11.0.16.1+1-21.3.3+2-windows-amd64.zip",
+        "11.0.17+7": "zip+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-openjdk11.0.17+7-21.3.3.1+1-windows-amd64.zip",
+        "11.0.18+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-openjdk11.0.18+10-22.3.1+1-windows-amd64.zip",
+        "11.0.19+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-openjdk11.0.19+7-22.3.2+1-windows-amd64.zip",
+        "11.0.20+8": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk11.0.20+8-22.3.3+1-windows-amd64.zip",
+        "11.0.20.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk11.0.20.1+1-22.3.3+2-windows-amd64.zip",
+        "11.0.21+10": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-openjdk11.0.21+10-22.3.4+1-windows-amd64.zip",
+        "11.0.22+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-openjdk11.0.22+12-22.3.5+1-windows-amd64.zip"
+      },
+      "jdk@liberica-nik-std-java17": {
+        "17.0.1+12": "zip+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-openjdk17-21.3.0-windows-amd64.zip",
+        "17.0.2+9": "zip+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-openjdk17-21.3.1-windows-amd64.zip",
+        "17.0.3+7": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk17.0.3+7-21.3.2+1-windows-amd64.zip",
+        "17.0.3.1+2": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk17.0.3.1+2-21.3.2+2-windows-amd64.zip",
+        "17.0.4+8": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk17.0.4+8-21.3.3+1-windows-amd64.zip",
+        "17.0.4.1+1": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk17.0.4.1+1-21.3.3+2-windows-amd64.zip",
+        "17.0.5+8": "zip+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-openjdk17.0.5+8-21.3.3.1+1-windows-amd64.zip",
+        "17.0.6+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-openjdk17.0.6+10-22.3.1+1-windows-amd64.zip",
+        "17.0.7+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-openjdk17.0.7+7-22.3.2+1-windows-amd64.zip",
+        "17.0.8+7": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk17.0.8+7-22.3.3+1-windows-amd64.zip",
+        "17.0.8.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk17.0.8.1+1-22.3.3+2-windows-amd64.zip",
+        "17.0.9+11": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-openjdk17.0.9+11-22.3.4+1-windows-amd64.zip",
+        "17.0.10+13": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-openjdk17.0.10+13-22.3.5+1-windows-amd64.zip",
+        "17.0.11+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-openjdk17.0.11+10-23.0.4+1-windows-amd64.zip",
+        "17.0.12+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-openjdk17.0.12+10-23.0.5+1-windows-amd64.zip",
+        "17.0.13+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-openjdk17.0.13+12-23.0.6+1-windows-amd64.zip"
+      },
+      "jdk@liberica-nik-std-java20": {
+        "20.0.1+10": "zip+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-openjdk20.0.1+10-23.0.0+1-windows-amd64.zip",
+        "20.0.2+10": "zip+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-openjdk20.0.2+10-23.0.1+1-windows-amd64.zip"
+      },
+      "jdk@liberica-nik-std-java21": {
+        "21+37.0.0": "zip+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-openjdk21+37-23.1.0+1-windows-amd64.zip",
+        "21.0.1+12": "zip+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-openjdk21.0.1+12-23.1.1+1-windows-amd64.zip",
+        "21.0.2+14": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-openjdk21.0.2+14-23.1.2+1-windows-amd64.zip",
+        "21.0.3+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-openjdk21.0.3+10-23.1.3+2-windows-amd64.zip",
+        "21.0.4+9": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-openjdk21.0.4+9-23.1.4+3-windows-amd64.zip",
+        "21.0.5+11": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-openjdk21.0.5+11-23.1.5+1-windows-amd64.zip"
+      },
+      "jdk@liberica-nik-std-java22": {
+        "22+37.0.0": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.0+1-22+37/bellsoft-liberica-vm-openjdk22+37-24.0.0+1-windows-amd64.zip",
+        "22.0.1+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.1+1-22.0.1+10/bellsoft-liberica-vm-openjdk22.0.1+10-24.0.1+1-windows-amd64.zip",
+        "22.0.2+11": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.2+1-22.0.2+11/bellsoft-liberica-vm-openjdk22.0.2+11-24.0.2+1-windows-amd64.zip"
+      },
+      "jdk@liberica-nik-std-java23": {
+        "23+38": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.0+1-23+38/bellsoft-liberica-vm-openjdk23+38-24.1.0+1-windows-amd64.zip",
+        "23.0.1+13": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.1+1-23.0.1+13/bellsoft-liberica-vm-openjdk23.0.1+13-24.1.1+1-windows-amd64.zip"
       },
       "jdk@temurin": {
         "1.8.0-302": "zip+https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08/OpenJDK8U-jdk_x64_windows_hotspot_8u302b08.zip",

--- a/indices/darwin-amd64.json
+++ b/indices/darwin-amd64.json
@@ -1292,6 +1292,162 @@
     "23.0.0": "zip+https://github.com/bell-sw/Liberica/releases/download/23+38/bellsoft-jdk23+38-macos-amd64-lite.zip",
     "23.0.1": "zip+https://github.com/bell-sw/Liberica/releases/download/23.0.1+13/bellsoft-jdk23.0.1+13-macos-amd64-lite.zip"
   },
+  "liberica-nik-core-java11": {
+    "11.0.11+9": "zip+https://download.bell-sw.com/vm/21.1.0/bellsoft-liberica-vm-core-openjdk11-21.1.0-macos-amd64.zip",
+    "11.0.12+7": "zip+https://download.bell-sw.com/vm/21.2.0/bellsoft-liberica-vm-core-openjdk11-21.2.0-macos-amd64.zip",
+    "11.0.13+8": "zip+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-core-openjdk11-21.3.0-macos-amd64.zip",
+    "11.0.14.1+1": "zip+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-core-openjdk11-21.3.1-macos-amd64.zip",
+    "11.0.15+10": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk11.0.15+10-21.3.2+1-macos-amd64.zip",
+    "11.0.15.1+2": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk11.0.15.1+2-21.3.2+2-macos-amd64.zip",
+    "11.0.16+8": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk11.0.16+8-21.3.3+1-macos-amd64.zip",
+    "11.0.16.1+1": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk11.0.16.1+1-21.3.3+2-macos-amd64.zip",
+    "11.0.17+7": "zip+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-core-openjdk11.0.17+7-21.3.3.1+1-macos-amd64.zip",
+    "11.0.18+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-core-openjdk11.0.18+10-22.3.1+1-macos-amd64.zip",
+    "11.0.19+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-core-openjdk11.0.19+7-22.3.2+1-macos-amd64.zip",
+    "11.0.20+8": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk11.0.20+8-22.3.3+1-macos-amd64.zip",
+    "11.0.20.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk11.0.20.1+1-22.3.3+2-macos-amd64.zip",
+    "11.0.21+10": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-core-openjdk11.0.21+9-22.3.4+1-macos-amd64.zip",
+    "11.0.22+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-core-openjdk11.0.22+12-22.3.5+1-macos-amd64.zip"
+  },
+  "liberica-nik-core-java17": {
+    "17.0.1+12": "zip+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-core-openjdk17-21.3.0-macos-amd64.zip",
+    "17.0.2+9": "zip+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-core-openjdk17-21.3.1-macos-amd64.zip",
+    "17.0.3+7": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk17.0.3+7-21.3.2+1-macos-amd64.zip",
+    "17.0.3.1+2": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk17.0.3.1+2-21.3.2+2-macos-amd64.zip",
+    "17.0.4+8": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk17.0.4+8-21.3.3+1-macos-amd64.zip",
+    "17.0.4.1+1": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk17.0.4.1+1-21.3.3+2-macos-amd64.zip",
+    "17.0.5+8": "zip+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-core-openjdk17.0.5+8-21.3.3.1+1-macos-amd64.zip",
+    "17.0.6+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-core-openjdk17.0.6+10-22.3.1+1-macos-amd64.zip",
+    "17.0.7+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-core-openjdk17.0.7+7-22.3.2+1-macos-amd64.zip",
+    "17.0.8+7": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk17.0.8+7-22.3.3+1-macos-amd64.zip",
+    "17.0.8.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk17.0.8.1+1-22.3.3+2-macos-amd64.zip",
+    "17.0.9+11": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-core-openjdk17.0.9+11-22.3.4+1-macos-amd64.zip",
+    "17.0.10+13": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-core-openjdk17.0.10+13-22.3.5+1-macos-amd64.zip",
+    "17.0.11+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-core-openjdk17.0.11+10-23.0.4+1-macos-amd64.zip",
+    "17.0.12+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-core-openjdk17.0.12+10-23.0.5+1-macos-amd64.zip",
+    "17.0.13+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-core-openjdk17.0.13+12-23.0.6+1-macos-amd64.zip"
+  },
+  "liberica-nik-core-java20": {
+    "20.0.1+10": "zip+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-core-openjdk20.0.1+10-23.0.0+1-macos-amd64.zip",
+    "20.0.2+10": "zip+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-core-openjdk20.0.2+10-23.0.1+1-macos-amd64.zip"
+  },
+  "liberica-nik-core-java21": {
+    "21+37.0.0": "zip+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-core-openjdk21+37-23.1.0+1-macos-amd64.zip",
+    "21.0.1+12": "zip+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-core-openjdk21.0.1+12-23.1.1+1-macos-amd64.zip",
+    "21.0.2+14": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-core-openjdk21.0.2+14-23.1.2+1-macos-amd64.zip",
+    "21.0.3+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-core-openjdk21.0.3+10-23.1.3+2-macos-amd64.zip",
+    "21.0.4+9": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-core-openjdk21.0.4+9-23.1.4+3-macos-amd64.zip",
+    "21.0.5+11": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-core-openjdk21.0.5+11-23.1.5+1-macos-amd64.zip"
+  },
+  "liberica-nik-full-java11": {
+    "11.0.14.1+1": "zip+https://download.bell-sw.com/vm/22.0.0.2/bellsoft-liberica-vm-full-openjdk11-22.0.0.2-macos-amd64.zip",
+    "11.0.15+10": "zip+https://download.bell-sw.com/vm/22.1.0/bellsoft-liberica-vm-full-openjdk11.0.15+10-22.1.0+1-macos-amd64.zip",
+    "11.0.15.1+2": "zip+https://download.bell-sw.com/vm/22.1.0/bellsoft-liberica-vm-full-openjdk11.0.15.1+2-22.1.0+2-macos-amd64.zip",
+    "11.0.16+8": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-full-openjdk11.0.16+8-22.2.0+2-macos-amd64.zip",
+    "11.0.16.1+1": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-full-openjdk11.0.16.1+1-22.2.0+3-macos-amd64.zip",
+    "11.0.17+7": "zip+https://download.bell-sw.com/vm/22.3.0/bellsoft-liberica-vm-full-openjdk11.0.17+7-22.3.0+2-macos-amd64.zip",
+    "11.0.18+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-full-openjdk11.0.18+10-22.3.1+1-macos-amd64.zip",
+    "11.0.19+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-full-openjdk11.0.19+7-22.3.2+1-macos-amd64.zip",
+    "11.0.20+8": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk11.0.20+8-22.3.3+1-macos-amd64.zip",
+    "11.0.20.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk11.0.20.1+1-22.3.3+2-macos-amd64.zip",
+    "11.0.21+10": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-full-openjdk11.0.21+9-22.3.4+1-macos-amd64.zip",
+    "11.0.22+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-full-openjdk11.0.22+12-22.3.5+1-macos-amd64.zip"
+  },
+  "liberica-nik-full-java17": {
+    "17.0.2+9": "zip+https://download.bell-sw.com/vm/22.0.0.2/bellsoft-liberica-vm-full-openjdk17-22.0.0.2-macos-amd64.zip",
+    "17.0.3+7": "zip+https://download.bell-sw.com/vm/22.1.0/bellsoft-liberica-vm-full-openjdk17.0.3+7-22.1.0+1-macos-amd64.zip",
+    "17.0.3.1+2": "zip+https://download.bell-sw.com/vm/22.1.0/bellsoft-liberica-vm-full-openjdk17.0.3.1+2-22.1.0+2-macos-amd64.zip",
+    "17.0.4+8": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-full-openjdk17.0.4+8-22.2.0+2-macos-amd64.zip",
+    "17.0.4.1+1": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-full-openjdk17.0.4.1+1-22.2.0+3-macos-amd64.zip",
+    "17.0.5+8": "zip+https://download.bell-sw.com/vm/22.3.0/bellsoft-liberica-vm-full-openjdk17.0.5+8-22.3.0+2-macos-amd64.zip",
+    "17.0.6+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-full-openjdk17.0.6+10-22.3.1+1-macos-amd64.zip",
+    "17.0.7+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-full-openjdk17.0.7+7-22.3.2+1-macos-amd64.zip",
+    "17.0.8+7": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk17.0.8+7-22.3.3+1-macos-amd64.zip",
+    "17.0.8.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk17.0.8.1+1-22.3.3+2-macos-amd64.zip",
+    "17.0.9+11": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-full-openjdk17.0.9+11-22.3.4+1-macos-amd64.zip",
+    "17.0.10+13": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-full-openjdk17.0.10+13-22.3.5+1-macos-amd64.zip",
+    "17.0.11+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-full-openjdk17.0.11+10-23.0.4+1-macos-amd64.zip",
+    "17.0.12+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-full-openjdk17.0.12+10-23.0.5+1-macos-amd64.zip",
+    "17.0.13+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-full-openjdk17.0.13+12-23.0.6+1-macos-amd64.zip"
+  },
+  "liberica-nik-full-java20": {
+    "20.0.1+10": "zip+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-full-openjdk20.0.1+10-23.0.0+1-macos-amd64.zip",
+    "20.0.2+10": "zip+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-full-openjdk20.0.2+10-23.0.1+1-macos-amd64.zip"
+  },
+  "liberica-nik-full-java21": {
+    "21+37.0.0": "zip+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-full-openjdk21+37-23.1.0+1-macos-amd64.zip",
+    "21.0.1+12": "zip+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-full-openjdk21.0.1+12-23.1.1+1-macos-amd64.zip",
+    "21.0.2+14": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-full-openjdk21.0.2+14-23.1.2+1-macos-amd64.zip",
+    "21.0.3+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-full-openjdk21.0.3+10-23.1.3+2-macos-amd64.zip",
+    "21.0.4+9": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-full-openjdk21.0.4+9-23.1.4+3-macos-amd64.zip",
+    "21.0.5+11": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-full-openjdk21.0.5+11-23.1.5+1-macos-amd64.zip"
+  },
+  "liberica-nik-full-java22": {
+    "22+37.0.0": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.0+1-22+37/bellsoft-liberica-vm-full-openjdk22+37-24.0.0+1-macos-amd64.zip",
+    "22.0.1+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.1+1-22.0.1+10/bellsoft-liberica-vm-full-openjdk22.0.1+10-24.0.1+1-macos-amd64.zip",
+    "22.0.2+11": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.2+1-22.0.2+11/bellsoft-liberica-vm-full-openjdk22.0.2+11-24.0.2+1-macos-amd64.zip"
+  },
+  "liberica-nik-full-java23": {
+    "23+38": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.0+1-23+38/bellsoft-liberica-vm-full-openjdk23+38-24.1.0+1-macos-amd64.zip",
+    "23.0.1+13": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.1+1-23.0.1+13/bellsoft-liberica-vm-full-openjdk23.0.1+13-24.1.1+1-macos-amd64.zip"
+  },
+  "liberica-nik-std-java11": {
+    "11.0.10+9": "zip+https://download.bell-sw.com/vm/21.0.0.2/bellsoft-liberica-vm-openjdk11-21.0.0.2-macos-amd64.zip",
+    "11.0.11+9": "zip+https://download.bell-sw.com/vm/21.1.0/bellsoft-liberica-vm-openjdk11-21.1.0-macos-amd64.zip",
+    "11.0.12+7": "zip+https://download.bell-sw.com/vm/21.2.0/bellsoft-liberica-vm-openjdk11-21.2.0-macos-amd64.zip",
+    "11.0.13+8": "zip+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-openjdk11-21.3.0-macos-amd64.zip",
+    "11.0.14.1+1": "zip+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-openjdk11-21.3.1-macos-amd64.zip",
+    "11.0.15+10": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk11.0.15+10-21.3.2+1-macos-amd64.zip",
+    "11.0.15.1+2": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk11.0.15.1+2-21.3.2+2-macos-amd64.zip",
+    "11.0.16+8": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk11.0.16+8-21.3.3+1-macos-amd64.zip",
+    "11.0.16.1+1": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk11.0.16.1+1-21.3.3+2-macos-amd64.zip",
+    "11.0.17+7": "zip+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-openjdk11.0.17+7-21.3.3.1+1-macos-amd64.zip",
+    "11.0.18+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-openjdk11.0.18+10-22.3.1+1-macos-amd64.zip",
+    "11.0.19+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-openjdk11.0.19+7-22.3.2+1-macos-amd64.zip",
+    "11.0.20+8": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk11.0.20+8-22.3.3+1-macos-amd64.zip",
+    "11.0.20.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk11.0.20.1+1-22.3.3+2-macos-amd64.zip",
+    "11.0.21+10": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-openjdk11.0.21+9-22.3.4+1-macos-amd64.zip",
+    "11.0.22+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-openjdk11.0.22+12-22.3.5+1-macos-amd64.zip"
+  },
+  "liberica-nik-std-java17": {
+    "17.0.1+12": "zip+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-openjdk17-21.3.0-macos-amd64.zip",
+    "17.0.2+9": "zip+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-openjdk17-21.3.1-macos-amd64.zip",
+    "17.0.3+7": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk17.0.3+7-21.3.2+1-macos-amd64.zip",
+    "17.0.3.1+2": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk17.0.3.1+2-21.3.2+2-macos-amd64.zip",
+    "17.0.4+8": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk17.0.4+8-21.3.3+1-macos-amd64.zip",
+    "17.0.4.1+1": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk17.0.4.1+1-21.3.3+2-macos-amd64.zip",
+    "17.0.5+8": "zip+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-openjdk17.0.5+8-21.3.3.1+1-macos-amd64.zip",
+    "17.0.6+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-openjdk17.0.6+10-22.3.1+1-macos-amd64.zip",
+    "17.0.7+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-openjdk17.0.7+7-22.3.2+1-macos-amd64.zip",
+    "17.0.8+7": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk17.0.8+7-22.3.3+1-macos-amd64.zip",
+    "17.0.8.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk17.0.8.1+1-22.3.3+2-macos-amd64.zip",
+    "17.0.9+11": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-openjdk17.0.9+11-22.3.4+1-macos-amd64.zip",
+    "17.0.10+13": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-openjdk17.0.10+13-22.3.5+1-macos-amd64.zip",
+    "17.0.11+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-openjdk17.0.11+10-23.0.4+1-macos-amd64.zip",
+    "17.0.12+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-openjdk17.0.12+10-23.0.5+1-macos-amd64.zip",
+    "17.0.13+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-openjdk17.0.13+12-23.0.6+1-macos-amd64.zip"
+  },
+  "liberica-nik-std-java20": {
+    "20.0.1+10": "zip+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-openjdk20.0.1+10-23.0.0+1-macos-amd64.zip",
+    "20.0.2+10": "zip+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-openjdk20.0.2+10-23.0.1+1-macos-amd64.zip"
+  },
+  "liberica-nik-std-java21": {
+    "21+37.0.0": "zip+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-openjdk21+37-23.1.0+1-macos-amd64.zip",
+    "21.0.1+12": "zip+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-openjdk21.0.1+12-23.1.1+1-macos-amd64.zip",
+    "21.0.2+14": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-openjdk21.0.2+14-23.1.2+1-macos-amd64.zip",
+    "21.0.3+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-openjdk21.0.3+10-23.1.3+2-macos-amd64.zip",
+    "21.0.4+9": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-openjdk21.0.4+9-23.1.4+3-macos-amd64.zip",
+    "21.0.5+11": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-openjdk21.0.5+11-23.1.5+1-macos-amd64.zip"
+  },
+  "liberica-nik-std-java22": {
+    "22+37.0.0": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.0+1-22+37/bellsoft-liberica-vm-openjdk22+37-24.0.0+1-macos-amd64.zip",
+    "22.0.1+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.1+1-22.0.1+10/bellsoft-liberica-vm-openjdk22.0.1+10-24.0.1+1-macos-amd64.zip",
+    "22.0.2+11": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.2+1-22.0.2+11/bellsoft-liberica-vm-openjdk22.0.2+11-24.0.2+1-macos-amd64.zip"
+  },
+  "liberica-nik-std-java23": {
+    "23+38": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.0+1-23+38/bellsoft-liberica-vm-openjdk23+38-24.1.0+1-macos-amd64.zip",
+    "23.0.1+13": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.1+1-23.0.1+13/bellsoft-liberica-vm-openjdk23.0.1+13-24.1.1+1-macos-amd64.zip"
+  },
   "temurin": {
     "8.0-302": "tgz+https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08/OpenJDK8U-jdk_x64_mac_hotspot_8u302b08.tar.gz",
     "8.0-312": "tgz+https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jdk_x64_mac_hotspot_8u312b07.tar.gz",

--- a/indices/darwin-arm64.json
+++ b/indices/darwin-arm64.json
@@ -834,6 +834,135 @@
     "23.0.0": "zip+https://github.com/bell-sw/Liberica/releases/download/23+38/bellsoft-jdk23+38-macos-aarch64-lite.zip",
     "23.0.1": "zip+https://github.com/bell-sw/Liberica/releases/download/23.0.1+13/bellsoft-jdk23.0.1+13-macos-aarch64-lite.zip"
   },
+  "liberica-nik-core-java11": {
+    "11.0.16+8": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-core-openjdk11.0.16+8-22.2.0+2-macos-aarch64.zip",
+    "11.0.16.1+1": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-core-openjdk11.0.16.1+1-22.2.0+3-macos-aarch64.zip",
+    "11.0.17+7": "zip+https://download.bell-sw.com/vm/22.3.0/bellsoft-liberica-vm-core-openjdk11.0.17+7-22.3.0+2-macos-aarch64.zip",
+    "11.0.18+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-core-openjdk11.0.18+10-22.3.1+1-macos-aarch64.zip",
+    "11.0.19+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-core-openjdk11.0.19+7-22.3.2+1-macos-aarch64.zip",
+    "11.0.20+8": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk11.0.20+8-22.3.3+1-macos-aarch64.zip",
+    "11.0.20.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk11.0.20.1+1-22.3.3+2-macos-aarch64.zip",
+    "11.0.21+10": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-core-openjdk11.0.21+9-22.3.4+1-macos-aarch64.zip",
+    "11.0.22+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-core-openjdk11.0.22+12-22.3.5+1-macos-aarch64.zip"
+  },
+  "liberica-nik-core-java17": {
+    "17.0.4+8": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-core-openjdk17.0.4+8-22.2.0+2-macos-aarch64.zip",
+    "17.0.4.1+1": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-core-openjdk17.0.4.1+1-22.2.0+3-macos-aarch64.zip",
+    "17.0.5+8": "zip+https://download.bell-sw.com/vm/22.3.0/bellsoft-liberica-vm-core-openjdk17.0.5+8-22.3.0+2-macos-aarch64.zip",
+    "17.0.6+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-core-openjdk17.0.6+10-22.3.1+1-macos-aarch64.zip",
+    "17.0.7+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-core-openjdk17.0.7+7-22.3.2+1-macos-aarch64.zip",
+    "17.0.8+7": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk17.0.8+7-22.3.3+1-macos-aarch64.zip",
+    "17.0.8.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk17.0.8.1+1-22.3.3+2-macos-aarch64.zip",
+    "17.0.9+11": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-core-openjdk17.0.9+11-22.3.4+1-macos-aarch64.zip",
+    "17.0.10+13": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-core-openjdk17.0.10+13-22.3.5+1-macos-aarch64.zip",
+    "17.0.11+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-core-openjdk17.0.11+10-23.0.4+1-macos-aarch64.zip",
+    "17.0.12+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-core-openjdk17.0.12+10-23.0.5+1-macos-aarch64.zip",
+    "17.0.13+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-core-openjdk17.0.13+12-23.0.6+1-macos-aarch64.zip"
+  },
+  "liberica-nik-core-java20": {
+    "20.0.1+10": "zip+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-core-openjdk20.0.1+10-23.0.0+1-macos-aarch64.zip",
+    "20.0.2+10": "zip+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-core-openjdk20.0.2+10-23.0.1+1-macos-aarch64.zip"
+  },
+  "liberica-nik-core-java21": {
+    "21+37.0.0": "zip+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-core-openjdk21+37-23.1.0+1-macos-aarch64.zip",
+    "21.0.1+12": "zip+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-core-openjdk21.0.1+12-23.1.1+1-macos-aarch64.zip",
+    "21.0.2+14": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-core-openjdk21.0.2+14-23.1.2+1-macos-aarch64.zip",
+    "21.0.3+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-core-openjdk21.0.3+10-23.1.3+2-macos-aarch64.zip",
+    "21.0.4+9": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-core-openjdk21.0.4+9-23.1.4+3-macos-aarch64.zip",
+    "21.0.5+11": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-core-openjdk21.0.5+11-23.1.5+1-macos-aarch64.zip"
+  },
+  "liberica-nik-full-java11": {
+    "11.0.16+8": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-full-openjdk11.0.16+8-22.2.0+2-macos-aarch64.zip",
+    "11.0.16.1+1": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-full-openjdk11.0.16.1+1-22.2.0+3-macos-aarch64.zip",
+    "11.0.17+7": "zip+https://download.bell-sw.com/vm/22.3.0/bellsoft-liberica-vm-full-openjdk11.0.17+7-22.3.0+2-macos-aarch64.zip",
+    "11.0.18+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-full-openjdk11.0.18+10-22.3.1+1-macos-aarch64.zip",
+    "11.0.19+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-full-openjdk11.0.19+7-22.3.2+1-macos-aarch64.zip",
+    "11.0.20+8": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk11.0.20+8-22.3.3+1-macos-aarch64.zip",
+    "11.0.20.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk11.0.20.1+1-22.3.3+2-macos-aarch64.zip",
+    "11.0.21+10": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-full-openjdk11.0.21+9-22.3.4+1-macos-aarch64.zip",
+    "11.0.22+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-full-openjdk11.0.22+12-22.3.5+1-macos-aarch64.zip"
+  },
+  "liberica-nik-full-java17": {
+    "17.0.4+8": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-full-openjdk17.0.4+8-22.2.0+2-macos-aarch64.zip",
+    "17.0.4.1+1": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-full-openjdk17.0.4.1+1-22.2.0+3-macos-aarch64.zip",
+    "17.0.5+8": "zip+https://download.bell-sw.com/vm/22.3.0/bellsoft-liberica-vm-full-openjdk17.0.5+8-22.3.0+2-macos-aarch64.zip",
+    "17.0.6+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-full-openjdk17.0.6+10-22.3.1+1-macos-aarch64.zip",
+    "17.0.7+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-full-openjdk17.0.7+7-22.3.2+1-macos-aarch64.zip",
+    "17.0.8+7": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk17.0.8+7-22.3.3+1-macos-aarch64.zip",
+    "17.0.8.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk17.0.8.1+1-22.3.3+2-macos-aarch64.zip",
+    "17.0.9+11": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-full-openjdk17.0.9+11-22.3.4+1-macos-aarch64.zip",
+    "17.0.10+13": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-full-openjdk17.0.10+13-22.3.5+1-macos-aarch64.zip",
+    "17.0.11+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-full-openjdk17.0.11+10-23.0.4+1-macos-aarch64.zip",
+    "17.0.12+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-full-openjdk17.0.12+10-23.0.5+1-macos-aarch64.zip",
+    "17.0.13+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-full-openjdk17.0.13+12-23.0.6+1-macos-aarch64.zip"
+  },
+  "liberica-nik-full-java20": {
+    "20.0.1+10": "zip+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-full-openjdk20.0.1+10-23.0.0+1-macos-aarch64.zip",
+    "20.0.2+10": "zip+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-full-openjdk20.0.2+10-23.0.1+1-macos-aarch64.zip"
+  },
+  "liberica-nik-full-java21": {
+    "21+37.0.0": "zip+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-full-openjdk21+37-23.1.0+1-macos-aarch64.zip",
+    "21.0.1+12": "zip+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-full-openjdk21.0.1+12-23.1.1+1-macos-aarch64.zip",
+    "21.0.2+14": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-full-openjdk21.0.2+14-23.1.2+1-macos-aarch64.zip",
+    "21.0.3+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-full-openjdk21.0.3+10-23.1.3+2-macos-aarch64.zip",
+    "21.0.4+9": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-full-openjdk21.0.4+9-23.1.4+3-macos-aarch64.zip",
+    "21.0.5+11": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-full-openjdk21.0.5+11-23.1.5+1-macos-aarch64.zip"
+  },
+  "liberica-nik-full-java22": {
+    "22+37.0.0": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.0+1-22+37/bellsoft-liberica-vm-full-openjdk22+37-24.0.0+1-macos-aarch64.zip",
+    "22.0.1+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.1+1-22.0.1+10/bellsoft-liberica-vm-full-openjdk22.0.1+10-24.0.1+1-macos-aarch64.zip",
+    "22.0.2+11": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.2+1-22.0.2+11/bellsoft-liberica-vm-full-openjdk22.0.2+11-24.0.2+1-macos-aarch64.zip"
+  },
+  "liberica-nik-full-java23": {
+    "23+38": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.0+1-23+38/bellsoft-liberica-vm-full-openjdk23+38-24.1.0+1-macos-aarch64.zip",
+    "23.0.1+13": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.1+1-23.0.1+13/bellsoft-liberica-vm-full-openjdk23.0.1+13-24.1.1+1-macos-aarch64.zip"
+  },
+  "liberica-nik-std-java11": {
+    "11.0.16+8": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-openjdk11.0.16+8-22.2.0+2-macos-aarch64.zip",
+    "11.0.16.1+1": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-openjdk11.0.16.1+1-22.2.0+3-macos-aarch64.zip",
+    "11.0.17+7": "zip+https://download.bell-sw.com/vm/22.3.0/bellsoft-liberica-vm-openjdk11.0.17+7-22.3.0+2-macos-aarch64.zip",
+    "11.0.18+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-openjdk11.0.18+10-22.3.1+1-macos-aarch64.zip",
+    "11.0.19+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-openjdk11.0.19+7-22.3.2+1-macos-aarch64.zip",
+    "11.0.20+8": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk11.0.20+8-22.3.3+1-macos-aarch64.zip",
+    "11.0.20.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk11.0.20.1+1-22.3.3+2-macos-aarch64.zip",
+    "11.0.21+10": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-openjdk11.0.21+9-22.3.4+1-macos-aarch64.zip",
+    "11.0.22+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-openjdk11.0.22+12-22.3.5+1-macos-aarch64.zip"
+  },
+  "liberica-nik-std-java17": {
+    "17.0.4+8": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-openjdk17.0.4+8-22.2.0+2-macos-aarch64.zip",
+    "17.0.4.1+1": "zip+https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-openjdk17.0.4.1+1-22.2.0+3-macos-aarch64.zip",
+    "17.0.5+8": "zip+https://download.bell-sw.com/vm/22.3.0/bellsoft-liberica-vm-openjdk17.0.5+8-22.3.0+2-macos-aarch64.zip",
+    "17.0.6+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-openjdk17.0.6+10-22.3.1+1-macos-aarch64.zip",
+    "17.0.7+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-openjdk17.0.7+7-22.3.2+1-macos-aarch64.zip",
+    "17.0.8+7": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk17.0.8+7-22.3.3+1-macos-aarch64.zip",
+    "17.0.8.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk17.0.8.1+1-22.3.3+2-macos-aarch64.zip",
+    "17.0.9+11": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-openjdk17.0.9+11-22.3.4+1-macos-aarch64.zip",
+    "17.0.10+13": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-openjdk17.0.10+13-22.3.5+1-macos-aarch64.zip",
+    "17.0.11+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-openjdk17.0.11+10-23.0.4+1-macos-aarch64.zip",
+    "17.0.12+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-openjdk17.0.12+10-23.0.5+1-macos-aarch64.zip",
+    "17.0.13+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-openjdk17.0.13+12-23.0.6+1-macos-aarch64.zip"
+  },
+  "liberica-nik-std-java20": {
+    "20.0.1+10": "zip+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-openjdk20.0.1+10-23.0.0+1-macos-aarch64.zip",
+    "20.0.2+10": "zip+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-openjdk20.0.2+10-23.0.1+1-macos-aarch64.zip"
+  },
+  "liberica-nik-std-java21": {
+    "21+37.0.0": "zip+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-openjdk21+37-23.1.0+1-macos-aarch64.zip",
+    "21.0.1+12": "zip+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-openjdk21.0.1+12-23.1.1+1-macos-aarch64.zip",
+    "21.0.2+14": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-openjdk21.0.2+14-23.1.2+1-macos-aarch64.zip",
+    "21.0.3+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-openjdk21.0.3+10-23.1.3+2-macos-aarch64.zip",
+    "21.0.4+9": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-openjdk21.0.4+9-23.1.4+3-macos-aarch64.zip",
+    "21.0.5+11": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-openjdk21.0.5+11-23.1.5+1-macos-aarch64.zip"
+  },
+  "liberica-nik-std-java22": {
+    "22+37.0.0": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.0+1-22+37/bellsoft-liberica-vm-openjdk22+37-24.0.0+1-macos-aarch64.zip",
+    "22.0.1+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.1+1-22.0.1+10/bellsoft-liberica-vm-openjdk22.0.1+10-24.0.1+1-macos-aarch64.zip",
+    "22.0.2+11": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.2+1-22.0.2+11/bellsoft-liberica-vm-openjdk22.0.2+11-24.0.2+1-macos-aarch64.zip"
+  },
+  "liberica-nik-std-java23": {
+    "23+38": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.0+1-23+38/bellsoft-liberica-vm-openjdk23+38-24.1.0+1-macos-aarch64.zip",
+    "23.0.1+13": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.1+1-23.0.1+13/bellsoft-liberica-vm-openjdk23.0.1+13-24.1.1+1-macos-aarch64.zip"
+  },
   "temurin": {
     "11.0.15": "tgz+https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.15%2B10/OpenJDK11U-jdk_aarch64_mac_hotspot_11.0.15_10.tar.gz",
     "11.0.16": "tgz+https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.16%2B8/OpenJDK11U-jdk_aarch64_mac_hotspot_11.0.16_8.tar.gz",

--- a/indices/linux-amd64.json
+++ b/indices/linux-amd64.json
@@ -1319,6 +1319,164 @@
     "23.0.0": "tgz+https://github.com/bell-sw/Liberica/releases/download/23+38/bellsoft-jdk23+38-linux-amd64-lite.tar.gz",
     "23.0.1": "tgz+https://github.com/bell-sw/Liberica/releases/download/23.0.1+13/bellsoft-jdk23.0.1+13-linux-amd64-lite.tar.gz"
   },
+  "liberica-nik-core-java11": {
+    "11.0.11+9": "tgz+https://download.bell-sw.com/vm/21.1.0/bellsoft-liberica-vm-core-openjdk11-21.1.0-linux-amd64.tar.gz",
+    "11.0.12+7": "tgz+https://download.bell-sw.com/vm/21.2.0/bellsoft-liberica-vm-core-openjdk11-21.2.0-linux-amd64.tar.gz",
+    "11.0.13+8": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-core-openjdk11-21.3.0-linux-amd64.tar.gz",
+    "11.0.14.1+1": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-core-openjdk11-21.3.1-linux-amd64.tar.gz",
+    "11.0.15+10": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk11.0.15+10-21.3.2+1-linux-amd64.tar.gz",
+    "11.0.15.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk11.0.15.1+2-21.3.2+2-linux-amd64.tar.gz",
+    "11.0.16+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk11.0.16+8-21.3.3+1-linux-amd64.tar.gz",
+    "11.0.16.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk11.0.16.1+1-21.3.3+2-linux-amd64.tar.gz",
+    "11.0.17+7": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-core-openjdk11.0.17+7-21.3.3.1+1-linux-amd64.tar.gz",
+    "11.0.18+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-core-openjdk11.0.18+10-22.3.1+1-linux-amd64.tar.gz",
+    "11.0.19+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-core-openjdk11.0.19+7-22.3.2+1-linux-amd64.tar.gz",
+    "11.0.20+8": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk11.0.20+8-22.3.3+1-linux-amd64.tar.gz",
+    "11.0.20.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk11.0.20.1+1-22.3.3+2-linux-amd64.tar.gz",
+    "11.0.21+10": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-core-openjdk11.0.21+10-22.3.4+1-linux-amd64.tar.gz",
+    "11.0.22+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-core-openjdk11.0.22+12-22.3.5+1-linux-amd64.tar.gz"
+  },
+  "liberica-nik-core-java17": {
+    "17.0.1+12": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-core-openjdk17-21.3.0-linux-amd64.tar.gz",
+    "17.0.2+9": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-core-openjdk17-21.3.1-linux-amd64.tar.gz",
+    "17.0.3+7": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk17.0.3+7-21.3.2+1-linux-amd64.tar.gz",
+    "17.0.3.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk17.0.3.1+2-21.3.2+2-linux-amd64.tar.gz",
+    "17.0.4+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk17.0.4+8-21.3.3+1-linux-amd64.tar.gz",
+    "17.0.4.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk17.0.4.1+1-21.3.3+2-linux-amd64.tar.gz",
+    "17.0.5+8": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-core-openjdk17.0.5+8-21.3.3.1+1-linux-amd64.tar.gz",
+    "17.0.6+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-core-openjdk17.0.6+10-22.3.1+1-linux-amd64.tar.gz",
+    "17.0.7+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-core-openjdk17.0.7+7-22.3.2+1-linux-amd64.tar.gz",
+    "17.0.8+7": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk17.0.8+7-22.3.3+1-linux-amd64.tar.gz",
+    "17.0.8.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk17.0.8.1+1-22.3.3+2-linux-amd64.tar.gz",
+    "17.0.9+11": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-core-openjdk17.0.9+11-22.3.4+1-linux-amd64.tar.gz",
+    "17.0.10+13": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-core-openjdk17.0.10+13-22.3.5+1-linux-amd64.tar.gz",
+    "17.0.11+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-core-openjdk17.0.11+10-23.0.4+1-linux-amd64.tar.gz",
+    "17.0.12+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-core-openjdk17.0.12+10-23.0.5+1-linux-amd64.tar.gz",
+    "17.0.13+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-core-openjdk17.0.13+12-23.0.6+1-linux-amd64.tar.gz"
+  },
+  "liberica-nik-core-java20": {
+    "20.0.1+10": "tgz+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-core-openjdk20.0.1+10-23.0.0+1-linux-amd64.tar.gz",
+    "20.0.2+10": "tgz+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-core-openjdk20.0.2+10-23.0.1+1-linux-amd64.tar.gz"
+  },
+  "liberica-nik-core-java21": {
+    "21+37.0.0": "tgz+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-core-openjdk21+37-23.1.0+1-linux-amd64.tar.gz",
+    "21.0.1+12": "tgz+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-core-openjdk21.0.1+12-23.1.1+1-linux-amd64.tar.gz",
+    "21.0.2+14": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-core-openjdk21.0.2+14-23.1.2+1-linux-amd64.tar.gz",
+    "21.0.3+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-core-openjdk21.0.3+10-23.1.3+2-linux-amd64.tar.gz",
+    "21.0.4+9": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-core-openjdk21.0.4+9-23.1.4+3-linux-amd64.tar.gz",
+    "21.0.5+11": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-core-openjdk21.0.5+11-23.1.5+1-linux-amd64.tar.gz"
+  },
+  "liberica-nik-full-java11": {
+    "11.0.13+8": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-full-openjdk11-21.3.0-linux-amd64.tar.gz",
+    "11.0.14.1+1": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-full-openjdk11-21.3.1-linux-amd64.tar.gz",
+    "11.0.15+10": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-full-openjdk11.0.15+10-21.3.2+1-linux-amd64.tar.gz",
+    "11.0.15.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-full-openjdk11.0.15.1+2-21.3.2+2-linux-amd64.tar.gz",
+    "11.0.16+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-full-openjdk11.0.16+8-21.3.3+1-linux-amd64.tar.gz",
+    "11.0.16.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-full-openjdk11.0.16.1+1-21.3.3+2-linux-amd64.tar.gz",
+    "11.0.17+7": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-full-openjdk11.0.17+7-21.3.3.1+1-linux-amd64.tar.gz",
+    "11.0.18+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-full-openjdk11.0.18+10-22.3.1+1-linux-amd64.tar.gz",
+    "11.0.19+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-full-openjdk11.0.19+7-22.3.2+1-linux-amd64.tar.gz",
+    "11.0.20+8": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk11.0.20+8-22.3.3+1-linux-amd64.tar.gz",
+    "11.0.20.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk11.0.20.1+1-22.3.3+2-linux-amd64.tar.gz",
+    "11.0.21+10": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-full-openjdk11.0.21+10-22.3.4+1-linux-amd64.tar.gz",
+    "11.0.22+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-full-openjdk11.0.22+12-22.3.5+1-linux-amd64.tar.gz"
+  },
+  "liberica-nik-full-java17": {
+    "17.0.1+12": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-full-openjdk17-21.3.0-linux-amd64.tar.gz",
+    "17.0.2+9": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-full-openjdk17-21.3.1-linux-amd64.tar.gz",
+    "17.0.3+7": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-full-openjdk17.0.3+7-21.3.2+1-linux-amd64.tar.gz",
+    "17.0.3.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-full-openjdk17.0.3.1+2-21.3.2+2-linux-amd64.tar.gz",
+    "17.0.4+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-full-openjdk17.0.4+8-21.3.3+1-linux-amd64.tar.gz",
+    "17.0.4.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-full-openjdk17.0.4.1+1-21.3.3+2-linux-amd64.tar.gz",
+    "17.0.5+8": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-full-openjdk17.0.5+8-21.3.3.1+1-linux-amd64.tar.gz",
+    "17.0.6+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-full-openjdk17.0.6+10-22.3.1+1-linux-amd64.tar.gz",
+    "17.0.7+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-full-openjdk17.0.7+7-22.3.2+1-linux-amd64.tar.gz",
+    "17.0.8+7": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk17.0.8+7-22.3.3+1-linux-amd64.tar.gz",
+    "17.0.8.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk17.0.8.1+1-22.3.3+2-linux-amd64.tar.gz",
+    "17.0.9+11": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-full-openjdk17.0.9+11-22.3.4+1-linux-amd64.tar.gz",
+    "17.0.10+13": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-full-openjdk17.0.10+13-22.3.5+1-linux-amd64.tar.gz",
+    "17.0.11+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-full-openjdk17.0.11+10-23.0.4+1-linux-amd64.tar.gz",
+    "17.0.12+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-full-openjdk17.0.12+10-23.0.5+1-linux-amd64.tar.gz",
+    "17.0.13+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-full-openjdk17.0.13+12-23.0.6+1-linux-amd64.tar.gz"
+  },
+  "liberica-nik-full-java20": {
+    "20.0.1+10": "tgz+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-full-openjdk20.0.1+10-23.0.0+1-linux-amd64.tar.gz",
+    "20.0.2+10": "tgz+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-full-openjdk20.0.2+10-23.0.1+1-linux-amd64.tar.gz"
+  },
+  "liberica-nik-full-java21": {
+    "21+37.0.0": "tgz+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-full-openjdk21+37-23.1.0+1-linux-amd64.tar.gz",
+    "21.0.1+12": "tgz+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-full-openjdk21.0.1+12-23.1.1+1-linux-amd64.tar.gz",
+    "21.0.2+14": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-full-openjdk21.0.2+14-23.1.2+1-linux-amd64.tar.gz",
+    "21.0.3+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-full-openjdk21.0.3+10-23.1.3+2-linux-amd64.tar.gz",
+    "21.0.4+9": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-full-openjdk21.0.4+9-23.1.4+3-linux-amd64.tar.gz",
+    "21.0.5+11": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-full-openjdk21.0.5+11-23.1.5+1-linux-amd64.tar.gz"
+  },
+  "liberica-nik-full-java22": {
+    "22+37.0.0": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.0+1-22+37/bellsoft-liberica-vm-full-openjdk22+37-24.0.0+1-linux-amd64.tar.gz",
+    "22.0.1+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.1+1-22.0.1+10/bellsoft-liberica-vm-full-openjdk22.0.1+10-24.0.1+1-linux-amd64.tar.gz",
+    "22.0.2+11": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.2+1-22.0.2+11/bellsoft-liberica-vm-full-openjdk22.0.2+11-24.0.2+1-linux-amd64.tar.gz"
+  },
+  "liberica-nik-full-java23": {
+    "23+38": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.0+1-23+38/bellsoft-liberica-vm-full-openjdk23+38-24.1.0+1-linux-amd64.tar.gz",
+    "23.0.1+13": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.1+1-23.0.1+13/bellsoft-liberica-vm-full-openjdk23.0.1+13-24.1.1+1-linux-amd64.tar.gz"
+  },
+  "liberica-nik-std-java11": {
+    "11.0.10+9": "tgz+https://download.bell-sw.com/vm/21.0.0.2/bellsoft-liberica-vm-openjdk11-21.0.0.2-linux-amd64.tar.gz",
+    "11.0.11+9": "tgz+https://download.bell-sw.com/vm/21.1.0/bellsoft-liberica-vm-openjdk11-21.1.0-linux-amd64.tar.gz",
+    "11.0.12+7": "tgz+https://download.bell-sw.com/vm/21.2.0/bellsoft-liberica-vm-openjdk11-21.2.0-linux-amd64.tar.gz",
+    "11.0.13+8": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-openjdk11-21.3.0-linux-amd64.tar.gz",
+    "11.0.14.1+1": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-openjdk11-21.3.1-linux-amd64.tar.gz",
+    "11.0.15+10": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk11.0.15+10-21.3.2+1-linux-amd64.tar.gz",
+    "11.0.15.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk11.0.15.1+2-21.3.2+2-linux-amd64.tar.gz",
+    "11.0.16+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk11.0.16+8-21.3.3+1-linux-amd64.tar.gz",
+    "11.0.16.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk11.0.16.1+1-21.3.3+2-linux-amd64.tar.gz",
+    "11.0.17+7": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-openjdk11.0.17+7-21.3.3.1+1-linux-amd64.tar.gz",
+    "11.0.18+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-openjdk11.0.18+10-22.3.1+1-linux-amd64.tar.gz",
+    "11.0.19+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-openjdk11.0.19+7-22.3.2+1-linux-amd64.tar.gz",
+    "11.0.20+8": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk11.0.20+8-22.3.3+1-linux-amd64.tar.gz",
+    "11.0.20.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk11.0.20.1+1-22.3.3+2-linux-amd64.tar.gz",
+    "11.0.21+10": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-openjdk11.0.21+10-22.3.4+1-linux-amd64.tar.gz",
+    "11.0.22+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-openjdk11.0.22+12-22.3.5+1-linux-amd64.tar.gz"
+  },
+  "liberica-nik-std-java17": {
+    "17.0.1+12": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-openjdk17-21.3.0-linux-amd64.tar.gz",
+    "17.0.2+9": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-openjdk17-21.3.1-linux-amd64.tar.gz",
+    "17.0.3+7": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk17.0.3+7-21.3.2+1-linux-amd64.tar.gz",
+    "17.0.3.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk17.0.3.1+2-21.3.2+2-linux-amd64.tar.gz",
+    "17.0.4+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk17.0.4+8-21.3.3+1-linux-amd64.tar.gz",
+    "17.0.4.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk17.0.4.1+1-21.3.3+2-linux-amd64.tar.gz",
+    "17.0.5+8": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-openjdk17.0.5+8-21.3.3.1+1-linux-amd64.tar.gz",
+    "17.0.6+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-openjdk17.0.6+10-22.3.1+1-linux-amd64.tar.gz",
+    "17.0.7+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-openjdk17.0.7+7-22.3.2+1-linux-amd64.tar.gz",
+    "17.0.8+7": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk17.0.8+7-22.3.3+1-linux-amd64.tar.gz",
+    "17.0.8.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk17.0.8.1+1-22.3.3+2-linux-amd64.tar.gz",
+    "17.0.9+11": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-openjdk17.0.9+11-22.3.4+1-linux-amd64.tar.gz",
+    "17.0.10+13": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-openjdk17.0.10+13-22.3.5+1-linux-amd64.tar.gz",
+    "17.0.11+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-openjdk17.0.11+10-23.0.4+1-linux-amd64.tar.gz",
+    "17.0.12+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-openjdk17.0.12+10-23.0.5+1-linux-amd64.tar.gz",
+    "17.0.13+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-openjdk17.0.13+12-23.0.6+1-linux-amd64.tar.gz"
+  },
+  "liberica-nik-std-java20": {
+    "20.0.1+10": "tgz+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-openjdk20.0.1+10-23.0.0+1-linux-amd64.tar.gz",
+    "20.0.2+10": "tgz+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-openjdk20.0.2+10-23.0.1+1-linux-amd64.tar.gz"
+  },
+  "liberica-nik-std-java21": {
+    "21+37.0.0": "tgz+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-openjdk21+37-23.1.0+1-linux-amd64.tar.gz",
+    "21.0.1+12": "tgz+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-openjdk21.0.1+12-23.1.1+1-linux-amd64.tar.gz",
+    "21.0.2+14": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-openjdk21.0.2+14-23.1.2+1-linux-amd64.tar.gz",
+    "21.0.3+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-openjdk21.0.3+10-23.1.3+2-linux-amd64.tar.gz",
+    "21.0.4+9": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-openjdk21.0.4+9-23.1.4+3-linux-amd64.tar.gz",
+    "21.0.5+11": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-openjdk21.0.5+11-23.1.5+1-linux-amd64.tar.gz"
+  },
+  "liberica-nik-std-java22": {
+    "22+37.0.0": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.0+1-22+37/bellsoft-liberica-vm-openjdk22+37-24.0.0+1-linux-amd64.tar.gz",
+    "22.0.1+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.1+1-22.0.1+10/bellsoft-liberica-vm-openjdk22.0.1+10-24.0.1+1-linux-amd64.tar.gz",
+    "22.0.2+11": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.2+1-22.0.2+11/bellsoft-liberica-vm-openjdk22.0.2+11-24.0.2+1-linux-amd64.tar.gz"
+  },
+  "liberica-nik-std-java23": {
+    "23+38": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.0+1-23+38/bellsoft-liberica-vm-openjdk23+38-24.1.0+1-linux-amd64.tar.gz",
+    "23.0.1+13": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.1+1-23.0.1+13/bellsoft-liberica-vm-openjdk23.0.1+13-24.1.1+1-linux-amd64.tar.gz"
+  },
   "temurin": {
     "8.0-302": "tgz+https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u302b08.tar.gz",
     "8.0-312": "tgz+https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jdk_x64_linux_hotspot_8u312b07.tar.gz",

--- a/indices/linux-arm64.json
+++ b/indices/linux-arm64.json
@@ -1221,6 +1221,110 @@
     "23.0.0": "tgz+https://github.com/bell-sw/Liberica/releases/download/23+38/bellsoft-jdk23+38-linux-aarch64-lite.tar.gz",
     "23.0.1": "tgz+https://github.com/bell-sw/Liberica/releases/download/23.0.1+13/bellsoft-jdk23.0.1+13-linux-aarch64-lite.tar.gz"
   },
+  "liberica-nik-core-java11": {
+    "11.0.11+9": "tgz+https://download.bell-sw.com/vm/21.1.0/bellsoft-liberica-vm-core-openjdk11-21.1.0-linux-aarch64.tar.gz",
+    "11.0.12+7": "tgz+https://download.bell-sw.com/vm/21.2.0/bellsoft-liberica-vm-core-openjdk11-21.2.0-linux-aarch64.tar.gz",
+    "11.0.13+8": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-core-openjdk11-21.3.0-linux-aarch64.tar.gz",
+    "11.0.14.1+1": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-core-openjdk11-21.3.1-linux-aarch64.tar.gz",
+    "11.0.15+10": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk11.0.15+10-21.3.2+1-linux-aarch64.tar.gz",
+    "11.0.15.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk11.0.15.1+2-21.3.2+2-linux-aarch64.tar.gz",
+    "11.0.16+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk11.0.16+8-21.3.3+1-linux-aarch64.tar.gz",
+    "11.0.16.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk11.0.16.1+1-21.3.3+2-linux-aarch64.tar.gz",
+    "11.0.17+7": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-core-openjdk11.0.17+7-21.3.3.1+1-linux-aarch64.tar.gz",
+    "11.0.18+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-core-openjdk11.0.18+10-22.3.1+1-linux-aarch64.tar.gz",
+    "11.0.19+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-core-openjdk11.0.19+7-22.3.2+1-linux-aarch64.tar.gz",
+    "11.0.20+8": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk11.0.20+8-22.3.3+1-linux-aarch64.tar.gz",
+    "11.0.20.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk11.0.20.1+1-22.3.3+2-linux-aarch64.tar.gz",
+    "11.0.21+10": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-core-openjdk11.0.21+10-22.3.4+1-linux-aarch64.tar.gz",
+    "11.0.22+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-core-openjdk11.0.22+12-22.3.5+1-linux-aarch64.tar.gz"
+  },
+  "liberica-nik-core-java17": {
+    "17.0.1+12": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-core-openjdk17-21.3.0-linux-aarch64.tar.gz",
+    "17.0.2+9": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-core-openjdk17-21.3.1-linux-aarch64.tar.gz",
+    "17.0.3+7": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk17.0.3+7-21.3.2+1-linux-aarch64.tar.gz",
+    "17.0.3.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk17.0.3.1+2-21.3.2+2-linux-aarch64.tar.gz",
+    "17.0.4+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk17.0.4+8-21.3.3+1-linux-aarch64.tar.gz",
+    "17.0.4.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk17.0.4.1+1-21.3.3+2-linux-aarch64.tar.gz",
+    "17.0.5+8": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-core-openjdk17.0.5+8-21.3.3.1+1-linux-aarch64.tar.gz",
+    "17.0.6+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-core-openjdk17.0.6+10-22.3.1+1-linux-aarch64.tar.gz",
+    "17.0.7+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-core-openjdk17.0.7+7-22.3.2+1-linux-aarch64.tar.gz",
+    "17.0.8+7": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk17.0.8+7-22.3.3+1-linux-aarch64.tar.gz",
+    "17.0.8.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk17.0.8.1+1-22.3.3+2-linux-aarch64.tar.gz",
+    "17.0.9+11": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-core-openjdk17.0.9+11-22.3.4+1-linux-aarch64.tar.gz",
+    "17.0.10+13": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-core-openjdk17.0.10+13-22.3.5+1-linux-aarch64.tar.gz",
+    "17.0.11+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-core-openjdk17.0.11+10-23.0.4+1-linux-aarch64.tar.gz",
+    "17.0.12+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-core-openjdk17.0.12+10-23.0.5+1-linux-aarch64.tar.gz",
+    "17.0.13+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-core-openjdk17.0.13+12-23.0.6+1-linux-aarch64.tar.gz"
+  },
+  "liberica-nik-core-java20": {
+    "20.0.1+10": "tgz+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-core-openjdk20.0.1+10-23.0.0+1-linux-aarch64.tar.gz",
+    "20.0.2+10": "tgz+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-core-openjdk20.0.2+10-23.0.1+1-linux-aarch64.tar.gz"
+  },
+  "liberica-nik-core-java21": {
+    "21+37.0.0": "tgz+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-core-openjdk21+37-23.1.0+1-linux-aarch64.tar.gz",
+    "21.0.1+12": "tgz+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-core-openjdk21.0.1+12-23.1.1+1-linux-aarch64.tar.gz",
+    "21.0.2+14": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-core-openjdk21.0.2+14-23.1.2+1-linux-aarch64.tar.gz",
+    "21.0.3+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-core-openjdk21.0.3+10-23.1.3+2-linux-aarch64.tar.gz",
+    "21.0.4+9": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-core-openjdk21.0.4+9-23.1.4+3-linux-aarch64.tar.gz",
+    "21.0.5+11": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-core-openjdk21.0.5+11-23.1.5+1-linux-aarch64.tar.gz"
+  },
+  "liberica-nik-std-java11": {
+    "11.0.10+9": "tgz+https://download.bell-sw.com/vm/21.0.0.2/bellsoft-liberica-vm-openjdk11-21.0.0.2-linux-aarch64.tar.gz",
+    "11.0.11+9": "tgz+https://download.bell-sw.com/vm/21.1.0/bellsoft-liberica-vm-openjdk11-21.1.0-linux-aarch64.tar.gz",
+    "11.0.12+7": "tgz+https://download.bell-sw.com/vm/21.2.0/bellsoft-liberica-vm-openjdk11-21.2.0-linux-aarch64.tar.gz",
+    "11.0.13+8": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-openjdk11-21.3.0-linux-aarch64.tar.gz",
+    "11.0.14.1+1": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-openjdk11-21.3.1-linux-aarch64.tar.gz",
+    "11.0.15+10": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk11.0.15+10-21.3.2+1-linux-aarch64.tar.gz",
+    "11.0.15.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk11.0.15.1+2-21.3.2+2-linux-aarch64.tar.gz",
+    "11.0.16+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk11.0.16+8-21.3.3+1-linux-aarch64.tar.gz",
+    "11.0.16.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk11.0.16.1+1-21.3.3+2-linux-aarch64.tar.gz",
+    "11.0.17+7": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-openjdk11.0.17+7-21.3.3.1+1-linux-aarch64.tar.gz",
+    "11.0.18+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-openjdk11.0.18+10-22.3.1+1-linux-aarch64.tar.gz",
+    "11.0.19+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-openjdk11.0.19+7-22.3.2+1-linux-aarch64.tar.gz",
+    "11.0.20+8": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk11.0.20+8-22.3.3+1-linux-aarch64.tar.gz",
+    "11.0.20.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk11.0.20.1+1-22.3.3+2-linux-aarch64.tar.gz",
+    "11.0.21+10": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-openjdk11.0.21+10-22.3.4+1-linux-aarch64.tar.gz",
+    "11.0.22+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-openjdk11.0.22+12-22.3.5+1-linux-aarch64.tar.gz"
+  },
+  "liberica-nik-std-java17": {
+    "17.0.1+12": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-openjdk17-21.3.0-linux-aarch64.tar.gz",
+    "17.0.2+9": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-openjdk17-21.3.1-linux-aarch64.tar.gz",
+    "17.0.3+7": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk17.0.3+7-21.3.2+1-linux-aarch64.tar.gz",
+    "17.0.3.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk17.0.3.1+2-21.3.2+2-linux-aarch64.tar.gz",
+    "17.0.4+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk17.0.4+8-21.3.3+1-linux-aarch64.tar.gz",
+    "17.0.4.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk17.0.4.1+1-21.3.3+2-linux-aarch64.tar.gz",
+    "17.0.5+8": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-openjdk17.0.5+8-21.3.3.1+1-linux-aarch64.tar.gz",
+    "17.0.6+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-openjdk17.0.6+10-22.3.1+1-linux-aarch64.tar.gz",
+    "17.0.7+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-openjdk17.0.7+7-22.3.2+1-linux-aarch64.tar.gz",
+    "17.0.8+7": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk17.0.8+7-22.3.3+1-linux-aarch64.tar.gz",
+    "17.0.8.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk17.0.8.1+1-22.3.3+2-linux-aarch64.tar.gz",
+    "17.0.9+11": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-openjdk17.0.9+11-22.3.4+1-linux-aarch64.tar.gz",
+    "17.0.10+13": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-openjdk17.0.10+13-22.3.5+1-linux-aarch64.tar.gz",
+    "17.0.11+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-openjdk17.0.11+10-23.0.4+1-linux-aarch64.tar.gz",
+    "17.0.12+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-openjdk17.0.12+10-23.0.5+1-linux-aarch64.tar.gz",
+    "17.0.13+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-openjdk17.0.13+12-23.0.6+1-linux-aarch64.tar.gz"
+  },
+  "liberica-nik-std-java20": {
+    "20.0.1+10": "tgz+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-openjdk20.0.1+10-23.0.0+1-linux-aarch64.tar.gz",
+    "20.0.2+10": "tgz+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-openjdk20.0.2+10-23.0.1+1-linux-aarch64.tar.gz"
+  },
+  "liberica-nik-std-java21": {
+    "21+37.0.0": "tgz+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-openjdk21+37-23.1.0+1-linux-aarch64.tar.gz",
+    "21.0.1+12": "tgz+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-openjdk21.0.1+12-23.1.1+1-linux-aarch64.tar.gz",
+    "21.0.2+14": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-openjdk21.0.2+14-23.1.2+1-linux-aarch64.tar.gz",
+    "21.0.3+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-openjdk21.0.3+10-23.1.3+2-linux-aarch64.tar.gz",
+    "21.0.4+9": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-openjdk21.0.4+9-23.1.4+3-linux-aarch64.tar.gz",
+    "21.0.5+11": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-openjdk21.0.5+11-23.1.5+1-linux-aarch64.tar.gz"
+  },
+  "liberica-nik-std-java22": {
+    "22+37.0.0": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.0+1-22+37/bellsoft-liberica-vm-openjdk22+37-24.0.0+1-linux-aarch64.tar.gz",
+    "22.0.1+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.1+1-22.0.1+10/bellsoft-liberica-vm-openjdk22.0.1+10-24.0.1+1-linux-aarch64.tar.gz",
+    "22.0.2+11": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.2+1-22.0.2+11/bellsoft-liberica-vm-openjdk22.0.2+11-24.0.2+1-linux-aarch64.tar.gz"
+  },
+  "liberica-nik-std-java23": {
+    "23+38": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.0+1-23+38/bellsoft-liberica-vm-openjdk23+38-24.1.0+1-linux-aarch64.tar.gz",
+    "23.0.1+13": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.1+1-23.0.1+13/bellsoft-liberica-vm-openjdk23.0.1+13-24.1.1+1-linux-aarch64.tar.gz"
+  },
   "temurin": {
     "8.0-302": "tgz+https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_8u302b08.tar.gz",
     "8.0-312": "tgz+https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jdk_aarch64_linux_hotspot_8u312b07.tar.gz",

--- a/indices/linux-musl-amd64.json
+++ b/indices/linux-musl-amd64.json
@@ -656,6 +656,110 @@
     "23.0.0": "tgz+https://github.com/bell-sw/Liberica/releases/download/23+38/bellsoft-jdk23+38-linux-x64-musl-lite.tar.gz",
     "23.0.1": "tgz+https://github.com/bell-sw/Liberica/releases/download/23.0.1+13/bellsoft-jdk23.0.1+13-linux-x64-musl-lite.tar.gz"
   },
+  "liberica-nik-core-java11": {
+    "11.0.11+9": "tgz+https://download.bell-sw.com/vm/21.1.0/bellsoft-liberica-vm-core-openjdk11-21.1.0-linux-x64-musl.tar.gz",
+    "11.0.12+7": "tgz+https://download.bell-sw.com/vm/21.2.0/bellsoft-liberica-vm-core-openjdk11-21.2.0-linux-x64-musl.tar.gz",
+    "11.0.13+8": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-core-openjdk11-21.3.0-linux-x64-musl.tar.gz",
+    "11.0.14.1+1": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-core-openjdk11-21.3.1-linux-x64-musl.tar.gz",
+    "11.0.15+10": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk11.0.15+10-21.3.2+1-linux-x64-musl.tar.gz",
+    "11.0.15.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk11.0.15.1+2-21.3.2+2-linux-x64-musl.tar.gz",
+    "11.0.16+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk11.0.16+8-21.3.3+1-linux-x64-musl.tar.gz",
+    "11.0.16.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk11.0.16.1+1-21.3.3+2-linux-x64-musl.tar.gz",
+    "11.0.17+7": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-core-openjdk11.0.17+7-21.3.3.1+1-linux-x64-musl.tar.gz",
+    "11.0.18+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-core-openjdk11.0.18+10-22.3.1+1-linux-x64-musl.tar.gz",
+    "11.0.19+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-core-openjdk11.0.19+7-22.3.2+1-linux-x64-musl.tar.gz",
+    "11.0.20+8": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk11.0.20+8-22.3.3+1-linux-x64-musl.tar.gz",
+    "11.0.20.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk11.0.20.1+1-22.3.3+2-linux-x64-musl.tar.gz",
+    "11.0.21+10": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-core-openjdk11.0.21+10-22.3.4+1-linux-x64-musl.tar.gz",
+    "11.0.22+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-core-openjdk11.0.22+12-22.3.5+1-linux-x64-musl.tar.gz"
+  },
+  "liberica-nik-core-java17": {
+    "17.0.1+12": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-core-openjdk17-21.3.0-linux-x64-musl.tar.gz",
+    "17.0.2+9": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-core-openjdk17-21.3.1-linux-x64-musl.tar.gz",
+    "17.0.3+7": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk17.0.3+7-21.3.2+1-linux-x64-musl.tar.gz",
+    "17.0.3.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk17.0.3.1+2-21.3.2+2-linux-x64-musl.tar.gz",
+    "17.0.4+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk17.0.4+8-21.3.3+1-linux-x64-musl.tar.gz",
+    "17.0.4.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk17.0.4.1+1-21.3.3+2-linux-x64-musl.tar.gz",
+    "17.0.5+8": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-core-openjdk17.0.5+8-21.3.3.1+1-linux-x64-musl.tar.gz",
+    "17.0.6+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-core-openjdk17.0.6+10-22.3.1+1-linux-x64-musl.tar.gz",
+    "17.0.7+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-core-openjdk17.0.7+7-22.3.2+1-linux-x64-musl.tar.gz",
+    "17.0.8+7": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk17.0.8+7-22.3.3+1-linux-x64-musl.tar.gz",
+    "17.0.8.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk17.0.8.1+1-22.3.3+2-linux-x64-musl.tar.gz",
+    "17.0.9+11": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-core-openjdk17.0.9+11-22.3.4+1-linux-x64-musl.tar.gz",
+    "17.0.10+13": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-core-openjdk17.0.10+13-22.3.5+1-linux-x64-musl.tar.gz",
+    "17.0.11+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-core-openjdk17.0.11+10-23.0.4+1-linux-x64-musl.tar.gz",
+    "17.0.12+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-core-openjdk17.0.12+10-23.0.5+1-linux-x64-musl.tar.gz",
+    "17.0.13+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-core-openjdk17.0.13+12-23.0.6+1-linux-x64-musl.tar.gz"
+  },
+  "liberica-nik-core-java20": {
+    "20.0.1+10": "tgz+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-core-openjdk20.0.1+10-23.0.0+1-linux-x64-musl.tar.gz",
+    "20.0.2+10": "tgz+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-core-openjdk20.0.2+10-23.0.1+1-linux-x64-musl.tar.gz"
+  },
+  "liberica-nik-core-java21": {
+    "21+37.0.0": "tgz+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-core-openjdk21+37-23.1.0+1-linux-x64-musl.tar.gz",
+    "21.0.1+12": "tgz+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-core-openjdk21.0.1+12-23.1.1+1-linux-x64-musl.tar.gz",
+    "21.0.2+14": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-core-openjdk21.0.2+14-23.1.2+1-linux-x64-musl.tar.gz",
+    "21.0.3+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-core-openjdk21.0.3+10-23.1.3+2-linux-x64-musl.tar.gz",
+    "21.0.4+9": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-core-openjdk21.0.4+9-23.1.4+3-linux-x64-musl.tar.gz",
+    "21.0.5+11": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-core-openjdk21.0.5+11-23.1.5+1-linux-x64-musl.tar.gz"
+  },
+  "liberica-nik-std-java11": {
+    "11.0.10+9": "tgz+https://download.bell-sw.com/vm/21.0.0.2/bellsoft-liberica-vm-openjdk11-21.0.0.2-linux-x64-musl.tar.gz",
+    "11.0.11+9": "tgz+https://download.bell-sw.com/vm/21.1.0/bellsoft-liberica-vm-openjdk11-21.1.0-linux-x64-musl.tar.gz",
+    "11.0.12+7": "tgz+https://download.bell-sw.com/vm/21.2.0/bellsoft-liberica-vm-openjdk11-21.2.0-linux-x64-musl.tar.gz",
+    "11.0.13+8": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-openjdk11-21.3.0-linux-x64-musl.tar.gz",
+    "11.0.14.1+1": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-openjdk11-21.3.1-linux-x64-musl.tar.gz",
+    "11.0.15+10": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk11.0.15+10-21.3.2+1-linux-x64-musl.tar.gz",
+    "11.0.15.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk11.0.15.1+2-21.3.2+2-linux-x64-musl.tar.gz",
+    "11.0.16+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk11.0.16+8-21.3.3+1-linux-x64-musl.tar.gz",
+    "11.0.16.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk11.0.16.1+1-21.3.3+2-linux-x64-musl.tar.gz",
+    "11.0.17+7": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-openjdk11.0.17+7-21.3.3.1+1-linux-x64-musl.tar.gz",
+    "11.0.18+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-openjdk11.0.18+10-22.3.1+1-linux-x64-musl.tar.gz",
+    "11.0.19+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-openjdk11.0.19+7-22.3.2+1-linux-x64-musl.tar.gz",
+    "11.0.20+8": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk11.0.20+8-22.3.3+1-linux-x64-musl.tar.gz",
+    "11.0.20.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk11.0.20.1+1-22.3.3+2-linux-x64-musl.tar.gz",
+    "11.0.21+10": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-openjdk11.0.21+10-22.3.4+1-linux-x64-musl.tar.gz",
+    "11.0.22+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-openjdk11.0.22+12-22.3.5+1-linux-x64-musl.tar.gz"
+  },
+  "liberica-nik-std-java17": {
+    "17.0.1+12": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-openjdk17-21.3.0-linux-x64-musl.tar.gz",
+    "17.0.2+9": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-openjdk17-21.3.1-linux-x64-musl.tar.gz",
+    "17.0.3+7": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk17.0.3+7-21.3.2+1-linux-x64-musl.tar.gz",
+    "17.0.3.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk17.0.3.1+2-21.3.2+2-linux-x64-musl.tar.gz",
+    "17.0.4+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk17.0.4+8-21.3.3+1-linux-x64-musl.tar.gz",
+    "17.0.4.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk17.0.4.1+1-21.3.3+2-linux-x64-musl.tar.gz",
+    "17.0.5+8": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-openjdk17.0.5+8-21.3.3.1+1-linux-x64-musl.tar.gz",
+    "17.0.6+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-openjdk17.0.6+10-22.3.1+1-linux-x64-musl.tar.gz",
+    "17.0.7+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-openjdk17.0.7+7-22.3.2+1-linux-x64-musl.tar.gz",
+    "17.0.8+7": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk17.0.8+7-22.3.3+1-linux-x64-musl.tar.gz",
+    "17.0.8.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk17.0.8.1+1-22.3.3+2-linux-x64-musl.tar.gz",
+    "17.0.9+11": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-openjdk17.0.9+11-22.3.4+1-linux-x64-musl.tar.gz",
+    "17.0.10+13": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-openjdk17.0.10+13-22.3.5+1-linux-x64-musl.tar.gz",
+    "17.0.11+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-openjdk17.0.11+10-23.0.4+1-linux-x64-musl.tar.gz",
+    "17.0.12+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-openjdk17.0.12+10-23.0.5+1-linux-x64-musl.tar.gz",
+    "17.0.13+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-openjdk17.0.13+12-23.0.6+1-linux-x64-musl.tar.gz"
+  },
+  "liberica-nik-std-java20": {
+    "20.0.1+10": "tgz+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-openjdk20.0.1+10-23.0.0+1-linux-x64-musl.tar.gz",
+    "20.0.2+10": "tgz+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-openjdk20.0.2+10-23.0.1+1-linux-x64-musl.tar.gz"
+  },
+  "liberica-nik-std-java21": {
+    "21+37.0.0": "tgz+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-openjdk21+37-23.1.0+1-linux-x64-musl.tar.gz",
+    "21.0.1+12": "tgz+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-openjdk21.0.1+12-23.1.1+1-linux-x64-musl.tar.gz",
+    "21.0.2+14": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-openjdk21.0.2+14-23.1.2+1-linux-x64-musl.tar.gz",
+    "21.0.3+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-openjdk21.0.3+10-23.1.3+2-linux-x64-musl.tar.gz",
+    "21.0.4+9": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-openjdk21.0.4+9-23.1.4+3-linux-x64-musl.tar.gz",
+    "21.0.5+11": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-openjdk21.0.5+11-23.1.5+1-linux-x64-musl.tar.gz"
+  },
+  "liberica-nik-std-java22": {
+    "22+37.0.0": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.0+1-22+37/bellsoft-liberica-vm-openjdk22+37-24.0.0+1-linux-x64-musl.tar.gz",
+    "22.0.1+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.1+1-22.0.1+10/bellsoft-liberica-vm-openjdk22.0.1+10-24.0.1+1-linux-x64-musl.tar.gz",
+    "22.0.2+11": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.2+1-22.0.2+11/bellsoft-liberica-vm-openjdk22.0.2+11-24.0.2+1-linux-x64-musl.tar.gz"
+  },
+  "liberica-nik-std-java23": {
+    "23+38": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.0+1-23+38/bellsoft-liberica-vm-openjdk23+38-24.1.0+1-linux-x64-musl.tar.gz",
+    "23.0.1+13": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.1+1-23.0.1+13/bellsoft-liberica-vm-openjdk23.0.1+13-24.1.1+1-linux-x64-musl.tar.gz"
+  },
   "temurin": {
     "8.0-322": "tgz+https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u322-b06/OpenJDK8U-jdk_x64_alpine-linux_hotspot_8u322b06.tar.gz",
     "8.0-332": "tgz+https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u332-b09/OpenJDK8U-jdk_x64_alpine-linux_hotspot_8u332b09.tar.gz",

--- a/indices/linux-musl-arm64.json
+++ b/indices/linux-musl-arm64.json
@@ -354,6 +354,110 @@
     "23.0.0": "tgz+https://github.com/bell-sw/Liberica/releases/download/23+38/bellsoft-jdk23+38-linux-aarch64-musl-lite.tar.gz",
     "23.0.1": "tgz+https://github.com/bell-sw/Liberica/releases/download/23.0.1+13/bellsoft-jdk23.0.1+13-linux-aarch64-musl-lite.tar.gz"
   },
+  "liberica-nik-core-java11": {
+    "11.0.11+9": "tgz+https://download.bell-sw.com/vm/21.1.0/bellsoft-liberica-vm-core-openjdk11-21.1.0-linux-aarch64-musl.tar.gz",
+    "11.0.12+7": "tgz+https://download.bell-sw.com/vm/21.2.0/bellsoft-liberica-vm-core-openjdk11-21.2.0-linux-aarch64-musl.tar.gz",
+    "11.0.13+8": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-core-openjdk11-21.3.0-linux-aarch64-musl.tar.gz",
+    "11.0.14.1+1": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-core-openjdk11-21.3.1-linux-aarch64-musl.tar.gz",
+    "11.0.15+10": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk11.0.15+10-21.3.2+1-linux-aarch64-musl.tar.gz",
+    "11.0.15.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk11.0.15.1+2-21.3.2+2-linux-aarch64-musl.tar.gz",
+    "11.0.16+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk11.0.16+8-21.3.3+1-linux-aarch64-musl.tar.gz",
+    "11.0.16.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk11.0.16.1+1-21.3.3+2-linux-aarch64-musl.tar.gz",
+    "11.0.17+7": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-core-openjdk11.0.17+7-21.3.3.1+1-linux-aarch64-musl.tar.gz",
+    "11.0.18+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-core-openjdk11.0.18+10-22.3.1+1-linux-aarch64-musl.tar.gz",
+    "11.0.19+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-core-openjdk11.0.19+7-22.3.2+1-linux-aarch64-musl.tar.gz",
+    "11.0.20+8": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk11.0.20+8-22.3.3+1-linux-aarch64-musl.tar.gz",
+    "11.0.20.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk11.0.20.1+1-22.3.3+2-linux-aarch64-musl.tar.gz",
+    "11.0.21+10": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-core-openjdk11.0.21+10-22.3.4+1-linux-aarch64-musl.tar.gz",
+    "11.0.22+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-core-openjdk11.0.22+12-22.3.5+1-linux-aarch64-musl.tar.gz"
+  },
+  "liberica-nik-core-java17": {
+    "17.0.1+12": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-core-openjdk17-21.3.0-linux-aarch64-musl.tar.gz",
+    "17.0.2+9": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-core-openjdk17-21.3.1-linux-aarch64-musl.tar.gz",
+    "17.0.3+7": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk17.0.3+7-21.3.2+1-linux-aarch64-musl.tar.gz",
+    "17.0.3.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk17.0.3.1+2-21.3.2+2-linux-aarch64-musl.tar.gz",
+    "17.0.4+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk17.0.4+8-21.3.3+1-linux-aarch64-musl.tar.gz",
+    "17.0.4.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk17.0.4.1+1-21.3.3+2-linux-aarch64-musl.tar.gz",
+    "17.0.5+8": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-core-openjdk17.0.5+8-21.3.3.1+1-linux-aarch64-musl.tar.gz",
+    "17.0.6+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-core-openjdk17.0.6+10-22.3.1+1-linux-aarch64-musl.tar.gz",
+    "17.0.7+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-core-openjdk17.0.7+7-22.3.2+1-linux-aarch64-musl.tar.gz",
+    "17.0.8+7": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk17.0.8+7-22.3.3+1-linux-aarch64-musl.tar.gz",
+    "17.0.8.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk17.0.8.1+1-22.3.3+2-linux-aarch64-musl.tar.gz",
+    "17.0.9+11": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-core-openjdk17.0.9+11-22.3.4+1-linux-aarch64-musl.tar.gz",
+    "17.0.10+13": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-core-openjdk17.0.10+13-22.3.5+1-linux-aarch64-musl.tar.gz",
+    "17.0.11+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-core-openjdk17.0.11+10-23.0.4+1-linux-aarch64-musl.tar.gz",
+    "17.0.12+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-core-openjdk17.0.12+10-23.0.5+1-linux-aarch64-musl.tar.gz",
+    "17.0.13+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-core-openjdk17.0.13+12-23.0.6+1-linux-aarch64-musl.tar.gz"
+  },
+  "liberica-nik-core-java20": {
+    "20.0.1+10": "tgz+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-core-openjdk20.0.1+10-23.0.0+1-linux-aarch64-musl.tar.gz",
+    "20.0.2+10": "tgz+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-core-openjdk20.0.2+10-23.0.1+1-linux-aarch64-musl.tar.gz"
+  },
+  "liberica-nik-core-java21": {
+    "21+37.0.0": "tgz+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-core-openjdk21+37-23.1.0+1-linux-aarch64-musl.tar.gz",
+    "21.0.1+12": "tgz+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-core-openjdk21.0.1+12-23.1.1+1-linux-aarch64-musl.tar.gz",
+    "21.0.2+14": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-core-openjdk21.0.2+14-23.1.2+1-linux-aarch64-musl.tar.gz",
+    "21.0.3+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-core-openjdk21.0.3+10-23.1.3+2-linux-aarch64-musl.tar.gz",
+    "21.0.4+9": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-core-openjdk21.0.4+9-23.1.4+3-linux-aarch64-musl.tar.gz",
+    "21.0.5+11": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-core-openjdk21.0.5+11-23.1.5+1-linux-aarch64-musl.tar.gz"
+  },
+  "liberica-nik-std-java11": {
+    "11.0.10+9": "tgz+https://download.bell-sw.com/vm/21.0.0.2/bellsoft-liberica-vm-openjdk11-21.0.0.2-linux-aarch64-musl.tar.gz",
+    "11.0.11+9": "tgz+https://download.bell-sw.com/vm/21.1.0/bellsoft-liberica-vm-openjdk11-21.1.0-linux-aarch64-musl.tar.gz",
+    "11.0.12+7": "tgz+https://download.bell-sw.com/vm/21.2.0/bellsoft-liberica-vm-openjdk11-21.2.0-linux-aarch64-musl.tar.gz",
+    "11.0.13+8": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-openjdk11-21.3.0-linux-aarch64-musl.tar.gz",
+    "11.0.14.1+1": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-openjdk11-21.3.1-linux-aarch64-musl.tar.gz",
+    "11.0.15+10": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk11.0.15+10-21.3.2+1-linux-aarch64-musl.tar.gz",
+    "11.0.15.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk11.0.15.1+2-21.3.2+2-linux-aarch64-musl.tar.gz",
+    "11.0.16+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk11.0.16+8-21.3.3+1-linux-aarch64-musl.tar.gz",
+    "11.0.16.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk11.0.16.1+1-21.3.3+2-linux-aarch64-musl.tar.gz",
+    "11.0.17+7": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-openjdk11.0.17+7-21.3.3.1+1-linux-aarch64-musl.tar.gz",
+    "11.0.18+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-openjdk11.0.18+10-22.3.1+1-linux-aarch64-musl.tar.gz",
+    "11.0.19+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-openjdk11.0.19+7-22.3.2+1-linux-aarch64-musl.tar.gz",
+    "11.0.20+8": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk11.0.20+8-22.3.3+1-linux-aarch64-musl.tar.gz",
+    "11.0.20.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk11.0.20.1+1-22.3.3+2-linux-aarch64-musl.tar.gz",
+    "11.0.21+10": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-openjdk11.0.21+10-22.3.4+1-linux-aarch64-musl.tar.gz",
+    "11.0.22+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-openjdk11.0.22+12-22.3.5+1-linux-aarch64-musl.tar.gz"
+  },
+  "liberica-nik-std-java17": {
+    "17.0.1+12": "tgz+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-openjdk17-21.3.0-linux-aarch64-musl.tar.gz",
+    "17.0.2+9": "tgz+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-openjdk17-21.3.1-linux-aarch64-musl.tar.gz",
+    "17.0.3+7": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk17.0.3+7-21.3.2+1-linux-aarch64-musl.tar.gz",
+    "17.0.3.1+2": "tgz+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk17.0.3.1+2-21.3.2+2-linux-aarch64-musl.tar.gz",
+    "17.0.4+8": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk17.0.4+8-21.3.3+1-linux-aarch64-musl.tar.gz",
+    "17.0.4.1+1": "tgz+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk17.0.4.1+1-21.3.3+2-linux-aarch64-musl.tar.gz",
+    "17.0.5+8": "tgz+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-openjdk17.0.5+8-21.3.3.1+1-linux-aarch64-musl.tar.gz",
+    "17.0.6+10": "tgz+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-openjdk17.0.6+10-22.3.1+1-linux-aarch64-musl.tar.gz",
+    "17.0.7+7": "tgz+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-openjdk17.0.7+7-22.3.2+1-linux-aarch64-musl.tar.gz",
+    "17.0.8+7": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk17.0.8+7-22.3.3+1-linux-aarch64-musl.tar.gz",
+    "17.0.8.1+1": "tgz+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk17.0.8.1+1-22.3.3+2-linux-aarch64-musl.tar.gz",
+    "17.0.9+11": "tgz+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-openjdk17.0.9+11-22.3.4+1-linux-aarch64-musl.tar.gz",
+    "17.0.10+13": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-openjdk17.0.10+13-22.3.5+1-linux-aarch64-musl.tar.gz",
+    "17.0.11+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-openjdk17.0.11+10-23.0.4+1-linux-aarch64-musl.tar.gz",
+    "17.0.12+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-openjdk17.0.12+10-23.0.5+1-linux-aarch64-musl.tar.gz",
+    "17.0.13+12": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-openjdk17.0.13+12-23.0.6+1-linux-aarch64-musl.tar.gz"
+  },
+  "liberica-nik-std-java20": {
+    "20.0.1+10": "tgz+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-openjdk20.0.1+10-23.0.0+1-linux-aarch64-musl.tar.gz",
+    "20.0.2+10": "tgz+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-openjdk20.0.2+10-23.0.1+1-linux-aarch64-musl.tar.gz"
+  },
+  "liberica-nik-std-java21": {
+    "21+37.0.0": "tgz+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-openjdk21+37-23.1.0+1-linux-aarch64-musl.tar.gz",
+    "21.0.1+12": "tgz+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-openjdk21.0.1+12-23.1.1+1-linux-aarch64-musl.tar.gz",
+    "21.0.2+14": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-openjdk21.0.2+14-23.1.2+1-linux-aarch64-musl.tar.gz",
+    "21.0.3+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-openjdk21.0.3+10-23.1.3+2-linux-aarch64-musl.tar.gz",
+    "21.0.4+9": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-openjdk21.0.4+9-23.1.4+3-linux-aarch64-musl.tar.gz",
+    "21.0.5+11": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-openjdk21.0.5+11-23.1.5+1-linux-aarch64-musl.tar.gz"
+  },
+  "liberica-nik-std-java22": {
+    "22+37.0.0": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.0+1-22+37/bellsoft-liberica-vm-openjdk22+37-24.0.0+1-linux-aarch64-musl.tar.gz",
+    "22.0.1+10": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.1+1-22.0.1+10/bellsoft-liberica-vm-openjdk22.0.1+10-24.0.1+1-linux-aarch64-musl.tar.gz",
+    "22.0.2+11": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.2+1-22.0.2+11/bellsoft-liberica-vm-openjdk22.0.2+11-24.0.2+1-linux-aarch64-musl.tar.gz"
+  },
+  "liberica-nik-std-java23": {
+    "23+38": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.0+1-23+38/bellsoft-liberica-vm-openjdk23+38-24.1.0+1-linux-aarch64-musl.tar.gz",
+    "23.0.1+13": "tgz+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.1+1-23.0.1+13/bellsoft-liberica-vm-openjdk23.0.1+13-24.1.1+1-linux-aarch64-musl.tar.gz"
+  },
   "temurin": {
     "21.0.0": "tgz+https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21%2B35/OpenJDK21U-jdk_aarch64_alpine-linux_hotspot_21_35.tar.gz",
     "21.0.1": "tgz+https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_aarch64_alpine-linux_hotspot_21.0.1_12.tar.gz",

--- a/indices/windows-amd64.json
+++ b/indices/windows-amd64.json
@@ -1298,6 +1298,163 @@
     "23.0.0": "zip+https://github.com/bell-sw/Liberica/releases/download/23+38/bellsoft-jdk23+38-windows-amd64-lite.zip",
     "23.0.1": "zip+https://github.com/bell-sw/Liberica/releases/download/23.0.1+13/bellsoft-jdk23.0.1+13-windows-amd64-lite.zip"
   },
+  "liberica-nik-core-java11": {
+    "11.0.11+9": "zip+https://download.bell-sw.com/vm/21.1.0/bellsoft-liberica-vm-core-openjdk11-21.1.0-windows-amd64.zip",
+    "11.0.12+7": "zip+https://download.bell-sw.com/vm/21.2.0/bellsoft-liberica-vm-core-openjdk11-21.2.0-windows-amd64.zip",
+    "11.0.13+8": "zip+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-core-openjdk11-21.3.0-windows-amd64.zip",
+    "11.0.14.1+1": "zip+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-core-openjdk11-21.3.1-windows-amd64.zip",
+    "11.0.15+10": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk11.0.15+10-21.3.2+1-windows-amd64.zip",
+    "11.0.15.1+2": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk11.0.15.1+2-21.3.2+2-windows-amd64.zip",
+    "11.0.16+8": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk11.0.16+8-21.3.3+1-windows-amd64.zip",
+    "11.0.16.1+1": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk11.0.16.1+1-21.3.3+2-windows-amd64.zip",
+    "11.0.17+7": "zip+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-core-openjdk11.0.17+7-21.3.3.1+1-windows-amd64.zip",
+    "11.0.18+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-core-openjdk11.0.18+10-22.3.1+1-windows-amd64.zip",
+    "11.0.19+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-core-openjdk11.0.19+7-22.3.2+1-windows-amd64.zip",
+    "11.0.20+8": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk11.0.20+8-22.3.3+1-windows-amd64.zip",
+    "11.0.20.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk11.0.20.1+1-22.3.3+2-windows-amd64.zip",
+    "11.0.21+10": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-core-openjdk11.0.21+10-22.3.4+1-windows-amd64.zip",
+    "11.0.22+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-core-openjdk11.0.22+12-22.3.5+1-windows-amd64.zip"
+  },
+  "liberica-nik-core-java17": {
+    "17.0.1+12": "zip+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-core-openjdk17-21.3.0-windows-amd64.zip",
+    "17.0.2+9": "zip+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-core-openjdk17-21.3.1-windows-amd64.zip",
+    "17.0.3+7": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk17.0.3+7-21.3.2+1-windows-amd64.zip",
+    "17.0.3.1+2": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-core-openjdk17.0.3.1+2-21.3.2+2-windows-amd64.zip",
+    "17.0.4+8": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk17.0.4+8-21.3.3+1-windows-amd64.zip",
+    "17.0.4.1+1": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-core-openjdk17.0.4.1+1-21.3.3+2-windows-amd64.zip",
+    "17.0.5+8": "zip+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-core-openjdk17.0.5+8-21.3.3.1+1-windows-amd64.zip",
+    "17.0.6+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-core-openjdk17.0.6+10-22.3.1+1-windows-amd64.zip",
+    "17.0.7+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-core-openjdk17.0.7+7-22.3.2+1-windows-amd64.zip",
+    "17.0.8+7": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk17.0.8+7-22.3.3+1-windows-amd64.zip",
+    "17.0.8.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-core-openjdk17.0.8.1+1-22.3.3+2-windows-amd64.zip",
+    "17.0.9+11": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-core-openjdk17.0.9+11-22.3.4+1-windows-amd64.zip",
+    "17.0.10+13": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-core-openjdk17.0.10+13-22.3.5+1-windows-amd64.zip",
+    "17.0.11+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-core-openjdk17.0.11+10-23.0.4+1-windows-amd64.zip",
+    "17.0.12+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-core-openjdk17.0.12+10-23.0.5+1-windows-amd64.zip",
+    "17.0.13+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-core-openjdk17.0.13+12-23.0.6+1-windows-amd64.zip"
+  },
+  "liberica-nik-core-java20": {
+    "20.0.1+10": "zip+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-core-openjdk20.0.1+10-23.0.0+1-windows-amd64.zip",
+    "20.0.2+10": "zip+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-core-openjdk20.0.2+10-23.0.1+1-windows-amd64.zip"
+  },
+  "liberica-nik-core-java21": {
+    "21+37.0.0": "zip+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-core-openjdk21+37-23.1.0+1-windows-amd64.zip",
+    "21.0.1+12": "zip+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-core-openjdk21.0.1+12-23.1.1+1-windows-amd64.zip",
+    "21.0.2+14": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-core-openjdk21.0.2+14-23.1.2+1-windows-amd64.zip",
+    "21.0.3+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-core-openjdk21.0.3+10-23.1.3+2-windows-amd64.zip",
+    "21.0.4+9": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-core-openjdk21.0.4+9-23.1.4+3-windows-amd64.zip",
+    "21.0.5+11": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-core-openjdk21.0.5+11-23.1.5+1-windows-amd64.zip"
+  },
+  "liberica-nik-full-java11": {
+    "11.0.13+8": "zip+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-full-openjdk11-21.3.0-windows-amd64.zip",
+    "11.0.14.1+1": "zip+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-full-openjdk11-21.3.1-windows-amd64.zip",
+    "11.0.15+10": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-full-openjdk11.0.15+10-21.3.2+1-windows-amd64.zip",
+    "11.0.15.1+2": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-full-openjdk11.0.15.1+2-21.3.2+2-windows-amd64.zip",
+    "11.0.16+8": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-full-openjdk11.0.16+8-21.3.3+1-windows-amd64.zip",
+    "11.0.16.1+1": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-full-openjdk11.0.16.1+1-21.3.3+2-windows-amd64.zip",
+    "11.0.17+7": "zip+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-full-openjdk11.0.17+7-21.3.3.1+1-windows-amd64.zip",
+    "11.0.18+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-full-openjdk11.0.18+10-22.3.1+1-windows-amd64.zip",
+    "11.0.19+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-full-openjdk11.0.19+7-22.3.2+1-windows-amd64.zip",
+    "11.0.20+8": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk11.0.20+8-22.3.3+1-windows-amd64.zip",
+    "11.0.20.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk11.0.20.1+1-22.3.3+2-windows-amd64.zip",
+    "11.0.21+10": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-full-openjdk11.0.21+10-22.3.4+1-windows-amd64.zip",
+    "11.0.22+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-full-openjdk11.0.22+12-22.3.5+1-windows-amd64.zip"
+  },
+  "liberica-nik-full-java17": {
+    "17.0.1+12": "zip+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-full-openjdk17-21.3.0-windows-amd64.zip",
+    "17.0.2+9": "zip+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-full-openjdk17-21.3.1-windows-amd64.zip",
+    "17.0.3+7": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-full-openjdk17.0.3+7-21.3.2+1-windows-amd64.zip",
+    "17.0.3.1+2": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-full-openjdk17.0.3.1+2-21.3.2+2-windows-amd64.zip",
+    "17.0.4+8": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-full-openjdk17.0.4+8-21.3.3+1-windows-amd64.zip",
+    "17.0.4.1+1": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-full-openjdk17.0.4.1+1-21.3.3+2-windows-amd64.zip",
+    "17.0.5+8": "zip+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-full-openjdk17.0.5+8-21.3.3.1+1-windows-amd64.zip",
+    "17.0.6+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-full-openjdk17.0.6+10-22.3.1+1-windows-amd64.zip",
+    "17.0.7+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-full-openjdk17.0.7+7-22.3.2+1-windows-amd64.zip",
+    "17.0.8+7": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk17.0.8+7-22.3.3+1-windows-amd64.zip",
+    "17.0.8.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-full-openjdk17.0.8.1+1-22.3.3+2-windows-amd64.zip",
+    "17.0.9+11": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-full-openjdk17.0.9+11-22.3.4+1-windows-amd64.zip",
+    "17.0.10+13": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-full-openjdk17.0.10+13-22.3.5+1-windows-amd64.zip",
+    "17.0.11+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-full-openjdk17.0.11+10-23.0.4+1-windows-amd64.zip",
+    "17.0.12+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-full-openjdk17.0.12+10-23.0.5+1-windows-amd64.zip",
+    "17.0.13+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-full-openjdk17.0.13+12-23.0.6+1-windows-amd64.zip"
+  },
+  "liberica-nik-full-java20": {
+    "20.0.1+10": "zip+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-full-openjdk20.0.1+10-23.0.0+1-windows-amd64.zip",
+    "20.0.2+10": "zip+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-full-openjdk20.0.2+10-23.0.1+1-windows-amd64.zip"
+  },
+  "liberica-nik-full-java21": {
+    "21+37.0.0": "zip+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-full-openjdk21+37-23.1.0+1-windows-amd64.zip",
+    "21.0.1+12": "zip+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-full-openjdk21.0.1+12-23.1.1+1-windows-amd64.zip",
+    "21.0.2+14": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-full-openjdk21.0.2+14-23.1.2+1-windows-amd64.zip",
+    "21.0.3+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-full-openjdk21.0.3+10-23.1.3+2-windows-amd64.zip",
+    "21.0.4+9": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-full-openjdk21.0.4+9-23.1.4+3-windows-amd64.zip",
+    "21.0.5+11": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-full-openjdk21.0.5+11-23.1.5+1-windows-amd64.zip"
+  },
+  "liberica-nik-full-java22": {
+    "22+37.0.0": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.0+1-22+37/bellsoft-liberica-vm-full-openjdk22+37-24.0.0+1-windows-amd64.zip",
+    "22.0.1+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.1+1-22.0.1+10/bellsoft-liberica-vm-full-openjdk22.0.1+10-24.0.1+1-windows-amd64.zip",
+    "22.0.2+11": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.2+1-22.0.2+11/bellsoft-liberica-vm-full-openjdk22.0.2+11-24.0.2+1-windows-amd64.zip"
+  },
+  "liberica-nik-full-java23": {
+    "23+38": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.0+1-23+38/bellsoft-liberica-vm-full-openjdk23+38-24.1.0+1-windows-amd64.zip",
+    "23.0.1+13": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.1+1-23.0.1+13/bellsoft-liberica-vm-full-openjdk23.0.1+13-24.1.1+1-windows-amd64.zip"
+  },
+  "liberica-nik-std-java11": {
+    "11.0.11+9": "zip+https://download.bell-sw.com/vm/21.1.0/bellsoft-liberica-vm-openjdk11-21.1.0-windows-amd64.zip",
+    "11.0.12+7": "zip+https://download.bell-sw.com/vm/21.2.0/bellsoft-liberica-vm-openjdk11-21.2.0-windows-amd64.zip",
+    "11.0.13+8": "zip+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-openjdk11-21.3.0-windows-amd64.zip",
+    "11.0.14.1+1": "zip+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-openjdk11-21.3.1-windows-amd64.zip",
+    "11.0.15+10": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk11.0.15+10-21.3.2+1-windows-amd64.zip",
+    "11.0.15.1+2": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk11.0.15.1+2-21.3.2+2-windows-amd64.zip",
+    "11.0.16+8": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk11.0.16+8-21.3.3+1-windows-amd64.zip",
+    "11.0.16.1+1": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk11.0.16.1+1-21.3.3+2-windows-amd64.zip",
+    "11.0.17+7": "zip+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-openjdk11.0.17+7-21.3.3.1+1-windows-amd64.zip",
+    "11.0.18+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-openjdk11.0.18+10-22.3.1+1-windows-amd64.zip",
+    "11.0.19+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-openjdk11.0.19+7-22.3.2+1-windows-amd64.zip",
+    "11.0.20+8": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk11.0.20+8-22.3.3+1-windows-amd64.zip",
+    "11.0.20.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk11.0.20.1+1-22.3.3+2-windows-amd64.zip",
+    "11.0.21+10": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-openjdk11.0.21+10-22.3.4+1-windows-amd64.zip",
+    "11.0.22+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-openjdk11.0.22+12-22.3.5+1-windows-amd64.zip"
+  },
+  "liberica-nik-std-java17": {
+    "17.0.1+12": "zip+https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-openjdk17-21.3.0-windows-amd64.zip",
+    "17.0.2+9": "zip+https://download.bell-sw.com/vm/21.3.1/bellsoft-liberica-vm-openjdk17-21.3.1-windows-amd64.zip",
+    "17.0.3+7": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk17.0.3+7-21.3.2+1-windows-amd64.zip",
+    "17.0.3.1+2": "zip+https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk17.0.3.1+2-21.3.2+2-windows-amd64.zip",
+    "17.0.4+8": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk17.0.4+8-21.3.3+1-windows-amd64.zip",
+    "17.0.4.1+1": "zip+https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk17.0.4.1+1-21.3.3+2-windows-amd64.zip",
+    "17.0.5+8": "zip+https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-openjdk17.0.5+8-21.3.3.1+1-windows-amd64.zip",
+    "17.0.6+10": "zip+https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-openjdk17.0.6+10-22.3.1+1-windows-amd64.zip",
+    "17.0.7+7": "zip+https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-openjdk17.0.7+7-22.3.2+1-windows-amd64.zip",
+    "17.0.8+7": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk17.0.8+7-22.3.3+1-windows-amd64.zip",
+    "17.0.8.1+1": "zip+https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk17.0.8.1+1-22.3.3+2-windows-amd64.zip",
+    "17.0.9+11": "zip+https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-openjdk17.0.9+11-22.3.4+1-windows-amd64.zip",
+    "17.0.10+13": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-17.0.10+13/bellsoft-liberica-vm-openjdk17.0.10+13-22.3.5+1-windows-amd64.zip",
+    "17.0.11+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-openjdk17.0.11+10-23.0.4+1-windows-amd64.zip",
+    "17.0.12+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-openjdk17.0.12+10-23.0.5+1-windows-amd64.zip",
+    "17.0.13+12": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-openjdk17.0.13+12-23.0.6+1-windows-amd64.zip"
+  },
+  "liberica-nik-std-java20": {
+    "20.0.1+10": "zip+https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-openjdk20.0.1+10-23.0.0+1-windows-amd64.zip",
+    "20.0.2+10": "zip+https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-openjdk20.0.2+10-23.0.1+1-windows-amd64.zip"
+  },
+  "liberica-nik-std-java21": {
+    "21+37.0.0": "zip+https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-openjdk21+37-23.1.0+1-windows-amd64.zip",
+    "21.0.1+12": "zip+https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-openjdk21.0.1+12-23.1.1+1-windows-amd64.zip",
+    "21.0.2+14": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-openjdk21.0.2+14-23.1.2+1-windows-amd64.zip",
+    "21.0.3+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+2-21.0.3+10/bellsoft-liberica-vm-openjdk21.0.3+10-23.1.3+2-windows-amd64.zip",
+    "21.0.4+9": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-openjdk21.0.4+9-23.1.4+3-windows-amd64.zip",
+    "21.0.5+11": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-openjdk21.0.5+11-23.1.5+1-windows-amd64.zip"
+  },
+  "liberica-nik-std-java22": {
+    "22+37.0.0": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.0+1-22+37/bellsoft-liberica-vm-openjdk22+37-24.0.0+1-windows-amd64.zip",
+    "22.0.1+10": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.1+1-22.0.1+10/bellsoft-liberica-vm-openjdk22.0.1+10-24.0.1+1-windows-amd64.zip",
+    "22.0.2+11": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.0.2+1-22.0.2+11/bellsoft-liberica-vm-openjdk22.0.2+11-24.0.2+1-windows-amd64.zip"
+  },
+  "liberica-nik-std-java23": {
+    "23+38": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.0+1-23+38/bellsoft-liberica-vm-openjdk23+38-24.1.0+1-windows-amd64.zip",
+    "23.0.1+13": "zip+https://github.com/bell-sw/LibericaNIK/releases/download/24.1.1+1-23.0.1+13/bellsoft-liberica-vm-openjdk23.0.1+13-24.1.1+1-windows-amd64.zip"
+  },
   "temurin": {
     "8.0-302": "zip+https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08/OpenJDK8U-jdk_x64_windows_hotspot_8u302b08.zip",
     "8.0-312": "zip+https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jdk_x64_windows_hotspot_8u312b07.zip",

--- a/src/coursier/jvmindex/GenerateIndex.scala
+++ b/src/coursier/jvmindex/GenerateIndex.scala
@@ -35,6 +35,7 @@ object GenerateIndex {
           Future(Temurin.fullIndex(GhToken.token)),
           Future(Zulu.index()),
           Future(Liberica.index()),
+          Future(LibericaNik.index()),
           Future(IbmSemeru.fullIndex(GhToken.token))
         )
 

--- a/src/coursier/jvmindex/LibericaNik.scala
+++ b/src/coursier/jvmindex/LibericaNik.scala
@@ -1,0 +1,143 @@
+package coursier.jvmindex
+
+import sttp.client3.quick._
+import scala.util.control.NonFatal
+import Index.{Arch, Os}
+
+object LibericaNik {
+
+  final case class LibericaNikEntry(
+    featureVersion: Int,
+    patchVersion: Int,
+    updateVersion: Int,
+    buildVersion: Int,
+    jdkVersion: String,
+    bitness: Int,
+    os: String,
+    url: String,
+    bundleType: String,
+    packageType: String,
+    architecture: String
+  ) {
+    lazy val sortKey = (featureVersion, patchVersion, updateVersion, buildVersion, packageType)
+
+    def indexOs: Os = os match {
+      case "macos" => Os("darwin")
+      case x       => Os(x)
+    }
+    def indexArchOpt = (architecture, bitness) match {
+      case ("arm", 32) => Some(Arch("arm"))
+      case ("arm", 64) => Some(Arch("arm64"))
+      case ("x86", 32) => Some(Arch("x86"))
+      case ("x86", 64) => Some(Arch("amd64"))
+      case ("ppc", 64) => Some(Arch("ppc64"))
+      case _           => None
+    }
+
+    def javaVersion: Int =
+      val semver = jdkVersion.split('+').head
+      semver.split('.').head.toInt
+
+    def indexJdkName = bundleType match {
+      case "core"     => "jdk@liberica-nik-core-java" + javaVersion
+      case "standard" => "jdk@liberica-nik-std-java" + javaVersion
+      case "full"     => "jdk@liberica-nik-full-java" + javaVersion
+      case x          => s"jdk@liberica-nik-$x-java" + javaVersion
+    }
+
+    def indexUrl = {
+      val packageTypePrefix = packageType match {
+        case "tar.gz" => "tgz"
+        case x        => x
+      }
+      s"$packageTypePrefix+$url"
+    }
+
+    def indexOpt: Option[Index] =
+      if packageType == "zip" || packageType == "tar.gz" then
+        indexArchOpt.map { indexArch =>
+          Index(indexOs, indexArch, indexJdkName, jdkVersion, indexUrl)
+        }
+      else
+        None
+  }
+
+  object LibericaNikEntry {
+    def couldNotFindJdkVersion(obj: ujson.Obj) =
+      throw Exception(s"Could not find jdkVersion in '$obj'")
+
+    def apply(obj: ujson.Obj): LibericaNikEntry =
+      val versionStr = obj("version").str
+
+      val buildVersionMaybe = versionStr.split('+')
+      val semver            = buildVersionMaybe(0)
+      val buildVersion = if buildVersionMaybe.length == 2 then buildVersionMaybe(1).toInt else 0
+      val (updateVersion, featureVersion, patchVersion) =
+        semver.split('.') match {
+          case Array(updateVersion, featureVersion, patchVersion, _) =>
+            (updateVersion.toInt, featureVersion.toInt, patchVersion.toInt)
+          case Array(updateVersion, featureVersion, patchVersion) =>
+            (updateVersion.toInt, featureVersion.toInt, patchVersion.toInt)
+          case Array(updateVersion, featureVersion) =>
+            (updateVersion.toInt, featureVersion.toInt, 0)
+          case Array(updateVersion) =>
+            (updateVersion.toInt, 0, 0)
+          case _ =>
+            throw Exception(s"Could not parse '$semver'")
+        }
+
+      val jdkVersion =
+        obj("components")
+          .arr
+          .filter(_.obj("component").str == "liberica")
+          .headOption
+          .map(_.obj("version").str)
+          .getOrElse(couldNotFindJdkVersion(obj))
+
+      LibericaNikEntry(
+        featureVersion = featureVersion,
+        patchVersion = patchVersion,
+        updateVersion = updateVersion,
+        buildVersion = buildVersion,
+        jdkVersion = jdkVersion,
+        bitness = obj("bitness").num.toInt,
+        os = obj("os").str,
+        url = obj("downloadUrl").str,
+        bundleType = obj("bundleType").str,
+        packageType = obj("packageType").str,
+        architecture = obj("architecture").str
+      )
+  }
+
+  def index(): Index = {
+
+    val url = uri"https://api.bell-sw.com/v1/nik/releases"
+    System.err.println(s"Getting $url")
+    val ua =
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/601.7.8 (KHTML, like Gecko) Version/9.1.3 Safari/537.86.7"
+    val resp = quickRequest
+      .header("User-Agent", ua)
+      .get(url)
+      .send(backend)
+    val json =
+      try ujson.read(resp.body)
+      catch {
+        case NonFatal(e) =>
+          System.err.println(s"Error parsing '${resp.body}'")
+          throw e
+      }
+
+    val count = json.arr.length
+    System.err.println(s"Found $count elements")
+
+    json
+      .arr
+      .toArray
+      .map(elem => LibericaNikEntry(elem.obj))
+      .sortBy(_.sortKey)
+      .iterator
+      .flatMap(_.indexOpt.iterator)
+      .foldLeft(Index.empty)(_ + _)
+  }
+
+}


### PR DESCRIPTION
Liberica NIK is a bellsoft distribution of GraalVM Community Edition (https://bell-sw.com/liberica-native-image-kit/) that contains multiple native-image patches for JDK UI libs like AWT and Swing.

Index was tested using `cs java --available --jvm-index (pwd)/index.json`, `cs java --jvm liberica-nik-std-java23:23.0.1+13 --jvm-index (pwd)/index.json` and `cs java --installed --jvm-index (pwd)/index.json` and seems to work just fine.

Index itself is based on Liberica entry but index structure is based on GraalVM CE.